### PR TITLE
[feat] using GOP Store Optimization

### DIFF
--- a/packages/on_demand_video_decoder/accvlab/on_demand_video_decoder/__init__.py
+++ b/packages/on_demand_video_decoder/accvlab/on_demand_video_decoder/__init__.py
@@ -73,10 +73,13 @@ except ImportError:
 from ._internal.decoder import CreateGopDecoder, CachedGopDecoder
 
 # Type definitions
-from ._internal.types import Codec
+from ._internal.types import Codec, GopRef
 
 # Utility functions
 from ._internal.utils import drop_videos_cache, DropCacheStatus
+
+# Shared GOP store (cross-process cache)
+from ._internal.shared_gop_store import SharedGopStore
 
 __all__ = [
     # C++ core interfaces
@@ -93,6 +96,9 @@ __all__ = [
     'CreateGopDecoder',
     # Type definitions
     'Codec',
+    'GopRef',
+    # Shared GOP store
+    'SharedGopStore',
     # Utility functions
     'drop_videos_cache',
     'DropCacheStatus',

--- a/packages/on_demand_video_decoder/accvlab/on_demand_video_decoder/_internal/shared_gop_store.py
+++ b/packages/on_demand_video_decoder/accvlab/on_demand_video_decoder/_internal/shared_gop_store.py
@@ -58,16 +58,18 @@ from .types import GopRef
 # ---------------------------------------------------------------------------
 
 # 96 bytes per entry -- fits in L1 cache for capacity < 500 (< 48 KB total).
-ENTRY_DTYPE = np.dtype([
-    ('video_path_hash', np.uint64),  # deterministic MD5 hash of video_path
-    ('first_frame_id', np.int32),    # first frame ID of this GOP
-    ('gop_len', np.int32),           # number of frames in this GOP
-    ('data_size', np.int32),         # actual GOP data size in bytes
-    ('state', np.uint8),             # 0=FREE, 1=USED
-    ('_pad', np.uint8, (3,)),        # alignment padding
-    ('access_tick', np.int64),       # monotonic counter for LRU ordering
-    ('shm_name', 'S64'),            # SharedMemory name for the data block
-])
+ENTRY_DTYPE = np.dtype(
+    [
+        ('video_path_hash', np.uint64),  # deterministic MD5 hash of video_path
+        ('first_frame_id', np.int32),  # first frame ID of this GOP
+        ('gop_len', np.int32),  # number of frames in this GOP
+        ('data_size', np.int32),  # actual GOP data size in bytes
+        ('state', np.uint8),  # 0=FREE, 1=USED
+        ('_pad', np.uint8, (3,)),  # alignment padding
+        ('access_tick', np.int64),  # monotonic counter for LRU ordering
+        ('shm_name', 'S64'),  # SharedMemory name for the data block
+    ]
+)
 
 _STATE_FREE = np.uint8(0)
 _STATE_USED = np.uint8(1)
@@ -119,22 +121,19 @@ class SharedGopStore:
         meta_size = capacity * ENTRY_DTYPE.itemsize
         if _create:
             _cleanup_stale_shm(meta_name)
-            self._meta_shm = shared_memory.SharedMemory(
-                name=meta_name, create=True, size=meta_size)
+            self._meta_shm = shared_memory.SharedMemory(name=meta_name, create=True, size=meta_size)
             # Zero-initialize all entries (state=FREE)
             np.frombuffer(self._meta_shm.buf, dtype=np.uint8)[:] = 0
         else:
             try:
-                self._meta_shm = shared_memory.SharedMemory(
-                    name=meta_name, create=False)
+                self._meta_shm = shared_memory.SharedMemory(name=meta_name, create=False)
             except FileNotFoundError:
                 raise FileNotFoundError(
                     f"SharedGopStore with store_id={store_id} not found. "
                     f"Call SharedGopStore.create() in the main process first."
                 )
 
-        self._entries = np.ndarray(
-            capacity, dtype=ENTRY_DTYPE, buffer=self._meta_shm.buf)
+        self._entries = np.ndarray(capacity, dtype=ENTRY_DTYPE, buffer=self._meta_shm.buf)
 
         # --- File-based lock (works across spawn'd processes) ---
         self._lock_path = f"/dev/shm/gs_lock_{store_id}"
@@ -147,12 +146,10 @@ class SharedGopStore:
         tick_name = f"gs_tick_{store_id}"
         if _create:
             _cleanup_stale_shm(tick_name)
-            self._tick_shm = shared_memory.SharedMemory(
-                name=tick_name, create=True, size=8)
+            self._tick_shm = shared_memory.SharedMemory(name=tick_name, create=True, size=8)
             np.frombuffer(self._tick_shm.buf, dtype=np.int64)[:] = 0
         else:
-            self._tick_shm = shared_memory.SharedMemory(
-                name=tick_name, create=False)
+            self._tick_shm = shared_memory.SharedMemory(name=tick_name, create=False)
         self._tick_arr = np.ndarray(1, dtype=np.int64, buffer=self._tick_shm.buf)
 
         # --- Per-process handle cache (not shared) ---
@@ -220,10 +217,11 @@ class SharedGopStore:
         vp_hash = _hash_video_path(video_path)
         for i in range(self.capacity):
             e = self._entries[i]
-            if (e['state'] == _STATE_USED
-                    and e['video_path_hash'] == vp_hash
-                    and e['first_frame_id'] <= frame_id
-                    < e['first_frame_id'] + e['gop_len']):
+            if (
+                e['state'] == _STATE_USED
+                and e['video_path_hash'] == vp_hash
+                and e['first_frame_id'] <= frame_id < e['first_frame_id'] + e['gop_len']
+            ):
                 e['access_tick'] = self._next_tick()
                 self._hits += 1
                 return GopRef(
@@ -235,8 +233,7 @@ class SharedGopStore:
         self._misses += 1
         return None
 
-    def put(self, video_path: str, first_frame_id: int,
-            gop_len: int, data: np.ndarray) -> GopRef:
+    def put(self, video_path: str, first_frame_id: int, gop_len: int, data: np.ndarray) -> GopRef:
         """Store GOP packet data and return a :class:`GopRef`.
 
         Holds ``flock`` during eviction + insertion to guarantee atomicity.
@@ -260,8 +257,7 @@ class SharedGopStore:
             # Clean up if same GOP was previously cached then evicted
             _cleanup_stale_shm(shm_name)
 
-            shm = shared_memory.SharedMemory(
-                name=shm_name, create=True, size=data_size)
+            shm = shared_memory.SharedMemory(name=shm_name, create=True, size=data_size)
             shm.buf[:data_size] = data.tobytes()
             shm.close()  # close handle; shm persists until unlink
 
@@ -301,6 +297,7 @@ class SharedGopStore:
                 shm = shared_memory.SharedMemory(name=shm_name, create=False)
             except FileNotFoundError:
                 import warnings
+
                 warnings.warn(
                     f"SharedGopStore: shm block '{shm_name}' not found. "
                     f"This means a GOP was evicted before the main process "
@@ -316,7 +313,7 @@ class SharedGopStore:
         else:
             shm = self._local_shm_handles[shm_name]
 
-        return np.frombuffer(shm.buf[:ref.data_size], dtype=np.uint8)
+        return np.frombuffer(shm.buf[: ref.data_size], dtype=np.uint8)
 
     def get_batch(self, refs: List[GopRef]) -> List[np.ndarray]:
         """Read a batch of GOPs from shared memory (zero-copy).
@@ -348,8 +345,7 @@ class SharedGopStore:
         """Per-process cache statistics."""
         total = self._hits + self._misses
         hit_rate = self._hits / total if total > 0 else 0.0
-        used_slots = int(np.count_nonzero(
-            self._entries['state'] == _STATE_USED))
+        used_slots = int(np.count_nonzero(self._entries['state'] == _STATE_USED))
         return {
             'hits': self._hits,
             'misses': self._misses,
@@ -483,6 +479,7 @@ class SharedGopStore:
 # ---------------------------------------------------------------------------
 # Module-private helpers
 # ---------------------------------------------------------------------------
+
 
 def _force_close_shm(shm) -> None:
     """Close a SharedMemory handle, suppressing BufferError from live numpy views.

--- a/packages/on_demand_video_decoder/accvlab/on_demand_video_decoder/_internal/shared_gop_store.py
+++ b/packages/on_demand_video_decoder/accvlab/on_demand_video_decoder/_internal/shared_gop_store.py
@@ -1,0 +1,516 @@
+# Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+SharedGopStore: Cross-process shared GOP store backed by POSIX SharedMemory.
+
+Workers ``put()`` GOP packet data and pass lightweight :class:`GopRef`
+references through the DataLoader IPC queue.  The main process
+``get_batch()`` to read references as zero-copy numpy views.
+
+Synchronization uses file-based locking (``flock``) which works across
+``spawn``'d DataLoader workers (unlike ``multiprocessing.Lock``).
+
+Usage::
+
+    # Main process -- create before spawning DataLoader workers
+    store = SharedGopStore.create(capacity=120, store_id=0)
+
+    # Worker -- attach to existing store
+    store = SharedGopStore.attach(capacity=120, store_id=0)
+    ref = store.lookup(video_path, frame_id)
+    if ref is None:
+        data = load_from_disk(...)
+        ref = store.put(video_path, first_frame_id, gop_len, data)
+    # Pass ``ref`` (lightweight) through DataLoader IPC queue
+
+    # Main process -- get batch of GOP data, then clean orphans
+    arrays = store.get_batch(refs)
+
+    # Main process -- shutdown
+    store.cleanup()
+"""
+
+import fcntl
+import glob as glob_mod
+import hashlib
+import os
+from multiprocessing import shared_memory
+from typing import List, Optional
+
+import numpy as np
+
+from .types import GopRef
+
+# ---------------------------------------------------------------------------
+# Metadata table layout
+# ---------------------------------------------------------------------------
+
+# 96 bytes per entry -- fits in L1 cache for capacity < 500 (< 48 KB total).
+ENTRY_DTYPE = np.dtype([
+    ('video_path_hash', np.uint64),  # deterministic MD5 hash of video_path
+    ('first_frame_id', np.int32),    # first frame ID of this GOP
+    ('gop_len', np.int32),           # number of frames in this GOP
+    ('data_size', np.int32),         # actual GOP data size in bytes
+    ('state', np.uint8),             # 0=FREE, 1=USED
+    ('_pad', np.uint8, (3,)),        # alignment padding
+    ('access_tick', np.int64),       # monotonic counter for LRU ordering
+    ('shm_name', 'S64'),            # SharedMemory name for the data block
+])
+
+_STATE_FREE = np.uint8(0)
+_STATE_USED = np.uint8(1)
+
+# SharedMemory name prefix used for GOP data blocks.
+_SHM_PREFIX = "gs"
+
+
+def _hash_video_path(video_path: str) -> np.uint64:
+    """Deterministic uint64 hash for a video path string.
+
+    Uses MD5 (truncated to 8 bytes) instead of Python's built-in ``hash()``,
+    because ``hash()`` uses a per-process random seed when
+    ``PYTHONHASHSEED != 0``, which breaks cross-process consistency with
+    ``spawn``'d DataLoader workers.
+    """
+    digest = hashlib.md5(video_path.encode()).digest()[:8]
+    return np.uint64(int.from_bytes(digest, 'little'))
+
+
+class SharedGopStore:
+    """Cross-process shared GOP store backed by POSIX SharedMemory.
+
+    Stores GOP packet data in per-GOP SharedMemory blocks.  A small
+    SharedMemory block holds the metadata table (index).  File-based
+    locking (``flock``) provides cross-process safety under ``spawn`` mode.
+
+    **Capacity sizing:**  ``capacity`` must exceed the maximum number of
+    GOPs that can be "in flight" (queued in the DataLoader + being
+    consumed by the training loop)::
+
+        min_capacity > (prefetch_factor * num_workers + 1) * batch_size * num_cameras
+
+    A recommended formula is ``batch_size * num_cameras * 10``.
+
+    Args:
+        capacity: Maximum number of GOPs to cache.
+        store_id: Unique identifier (typically ``LOCAL_RANK``).
+        _create: Internal flag -- use :meth:`create` / :meth:`attach`.
+    """
+
+    def __init__(self, capacity: int, store_id: int, _create: bool):
+        self.capacity = capacity
+        self.store_id = store_id
+        self._is_creator = _create
+
+        # --- Metadata SharedMemory ---
+        meta_name = f"gs_meta_{store_id}"
+        meta_size = capacity * ENTRY_DTYPE.itemsize
+        if _create:
+            _cleanup_stale_shm(meta_name)
+            self._meta_shm = shared_memory.SharedMemory(
+                name=meta_name, create=True, size=meta_size)
+            # Zero-initialize all entries (state=FREE)
+            np.frombuffer(self._meta_shm.buf, dtype=np.uint8)[:] = 0
+        else:
+            try:
+                self._meta_shm = shared_memory.SharedMemory(
+                    name=meta_name, create=False)
+            except FileNotFoundError:
+                raise FileNotFoundError(
+                    f"SharedGopStore with store_id={store_id} not found. "
+                    f"Call SharedGopStore.create() in the main process first."
+                )
+
+        self._entries = np.ndarray(
+            capacity, dtype=ENTRY_DTYPE, buffer=self._meta_shm.buf)
+
+        # --- File-based lock (works across spawn'd processes) ---
+        self._lock_path = f"/dev/shm/gs_lock_{store_id}"
+        if _create:
+            with open(self._lock_path, 'w'):
+                pass
+        self._lock_fd = os.open(self._lock_path, os.O_RDWR)
+
+        # --- Monotonic tick counter in a tiny SharedMemory ---
+        tick_name = f"gs_tick_{store_id}"
+        if _create:
+            _cleanup_stale_shm(tick_name)
+            self._tick_shm = shared_memory.SharedMemory(
+                name=tick_name, create=True, size=8)
+            np.frombuffer(self._tick_shm.buf, dtype=np.int64)[:] = 0
+        else:
+            self._tick_shm = shared_memory.SharedMemory(
+                name=tick_name, create=False)
+        self._tick_arr = np.ndarray(1, dtype=np.int64, buffer=self._tick_shm.buf)
+
+        # --- Per-process handle cache (not shared) ---
+        self._local_shm_handles = {}
+
+        # --- Stats (per-process, not shared) ---
+        self._hits = 0
+        self._misses = 0
+        self._puts = 0
+        self._evictions = 0
+
+    # ------------------------------------------------------------------ #
+    #  Factory class methods
+    # ------------------------------------------------------------------ #
+
+    @classmethod
+    def create(cls, capacity: int, store_id: int = 0) -> 'SharedGopStore':
+        """Allocate a new store.  Call from main process before spawning workers.
+
+        Args:
+            capacity: Max number of GOPs to cache.
+            store_id: Unique identifier (typically ``LOCAL_RANK``).
+        """
+        return cls(capacity=capacity, store_id=store_id, _create=True)
+
+    @classmethod
+    def attach(cls, capacity: int, store_id: int = 0) -> 'SharedGopStore':
+        """Attach to an existing store.  Call from worker processes.
+
+        Raises:
+            FileNotFoundError: If the store has not been created yet.
+        """
+        return cls(capacity=capacity, store_id=store_id, _create=False)
+
+    # ------------------------------------------------------------------ #
+    #  Locking helpers (flock)
+    # ------------------------------------------------------------------ #
+
+    def _lock(self):
+        fcntl.flock(self._lock_fd, fcntl.LOCK_EX)
+
+    def _unlock(self):
+        fcntl.flock(self._lock_fd, fcntl.LOCK_UN)
+
+    def _next_tick(self) -> int:
+        """Increment and return the monotonic tick counter.
+
+        Not truly atomic across processes without the lock, but the tick
+        is only used for LRU ordering -- a rare duplicate is harmless.
+        """
+        self._tick_arr[0] += 1
+        return int(self._tick_arr[0])
+
+    # ------------------------------------------------------------------ #
+    #  Worker API
+    # ------------------------------------------------------------------ #
+
+    def lookup(self, video_path: str, frame_id: int) -> Optional[GopRef]:
+        """Lock-free lookup for a cached GOP containing *frame_id*.
+
+        Returns a :class:`GopRef` on hit, ``None`` on miss.  Lock-free
+        design means the worst case is a stale miss (one extra disk read),
+        never a correctness issue.
+        """
+        vp_hash = _hash_video_path(video_path)
+        for i in range(self.capacity):
+            e = self._entries[i]
+            if (e['state'] == _STATE_USED
+                    and e['video_path_hash'] == vp_hash
+                    and e['first_frame_id'] <= frame_id
+                    < e['first_frame_id'] + e['gop_len']):
+                e['access_tick'] = self._next_tick()
+                self._hits += 1
+                return GopRef(
+                    shm_name=e['shm_name'].decode(),
+                    data_size=int(e['data_size']),
+                    first_frame_id=int(e['first_frame_id']),
+                    gop_len=int(e['gop_len']),
+                )
+        self._misses += 1
+        return None
+
+    def put(self, video_path: str, first_frame_id: int,
+            gop_len: int, data: np.ndarray) -> GopRef:
+        """Store GOP packet data and return a :class:`GopRef`.
+
+        Holds ``flock`` during eviction + insertion to guarantee atomicity.
+        Performs a double-check after acquiring the lock (another worker
+        may have inserted while we waited).
+        """
+        self._lock()
+        try:
+            # Double-check: another worker may have inserted while we waited
+            existing = self.lookup(video_path, first_frame_id)
+            if existing is not None:
+                return existing
+
+            slot_idx = self._find_free_or_evict()
+
+            # Content-addressed naming -- same GOP always gets the same name.
+            vp_hash = _hash_video_path(video_path)
+            shm_name = f"{_SHM_PREFIX}_{self.store_id}_{vp_hash}_{first_frame_id}"
+            data_size = int(data.nbytes)
+
+            # Clean up if same GOP was previously cached then evicted
+            _cleanup_stale_shm(shm_name)
+
+            shm = shared_memory.SharedMemory(
+                name=shm_name, create=True, size=data_size)
+            shm.buf[:data_size] = data.tobytes()
+            shm.close()  # close handle; shm persists until unlink
+
+            # Write metadata entry
+            self._entries[slot_idx]['video_path_hash'] = vp_hash
+            self._entries[slot_idx]['first_frame_id'] = first_frame_id
+            self._entries[slot_idx]['gop_len'] = gop_len
+            self._entries[slot_idx]['data_size'] = data_size
+            self._entries[slot_idx]['access_tick'] = self._next_tick()
+            self._entries[slot_idx]['shm_name'] = shm_name.encode()
+            # Set state last (acts as publish barrier for lock-free readers)
+            self._entries[slot_idx]['state'] = _STATE_USED
+
+            self._puts += 1
+            return GopRef(
+                shm_name=shm_name,
+                data_size=data_size,
+                first_frame_id=first_frame_id,
+                gop_len=gop_len,
+            )
+        finally:
+            self._unlock()
+
+    # ------------------------------------------------------------------ #
+    #  Main Process API
+    # ------------------------------------------------------------------ #
+
+    def read(self, ref: GopRef) -> np.ndarray:
+        """Zero-copy uint8 numpy view of GOP data in shared memory.
+
+        Caches ``SharedMemory`` handles per-process to avoid repeated
+        ``shm_open()`` system calls.
+        """
+        shm_name = ref.shm_name
+        if shm_name not in self._local_shm_handles:
+            try:
+                shm = shared_memory.SharedMemory(name=shm_name, create=False)
+            except FileNotFoundError:
+                import warnings
+                warnings.warn(
+                    f"SharedGopStore: shm block '{shm_name}' not found. "
+                    f"This means a GOP was evicted before the main process "
+                    f"could read it. Increase store capacity "
+                    f"(current: {self.capacity}) — it must exceed "
+                    f"(prefetch_factor * num_workers + 1) * batch_size * num_cameras. "
+                    f"Returning zeros as fallback.",
+                    RuntimeWarning,
+                    stacklevel=2,
+                )
+                return np.zeros(ref.data_size, dtype=np.uint8)
+            self._local_shm_handles[shm_name] = shm
+        else:
+            shm = self._local_shm_handles[shm_name]
+
+        return np.frombuffer(shm.buf[:ref.data_size], dtype=np.uint8)
+
+    def get_batch(self, refs: List[GopRef]) -> List[np.ndarray]:
+        """Read a batch of GOPs from shared memory (zero-copy).
+
+        Call once per training iteration from the main process.
+        Holds ``flock`` during the entire operation so that no worker can
+        evict a block while handles are being opened.  After opening,
+        orphaned shm blocks (evicted but not yet unlinked) are cleaned up.
+
+        Args:
+            refs: Flat list of :class:`GopRef` from DataLoader workers.
+
+        Returns:
+            List of zero-copy uint8 numpy views, same order as *refs*.
+        """
+        self._lock()
+        try:
+            result = [self.read(ref) for ref in refs]
+            self._unlink_orphans()
+            return result
+        finally:
+            self._unlock()
+
+    # ------------------------------------------------------------------ #
+    #  Stats
+    # ------------------------------------------------------------------ #
+
+    def get_stats(self) -> dict:
+        """Per-process cache statistics."""
+        total = self._hits + self._misses
+        hit_rate = self._hits / total if total > 0 else 0.0
+        used_slots = int(np.count_nonzero(
+            self._entries['state'] == _STATE_USED))
+        return {
+            'hits': self._hits,
+            'misses': self._misses,
+            'hit_rate': hit_rate,
+            'puts': self._puts,
+            'evictions': self._evictions,
+            'pool_usage': f"{used_slots}/{self.capacity}",
+        }
+
+    def reset_stats(self) -> None:
+        """Reset per-process statistics counters."""
+        self._hits = 0
+        self._misses = 0
+        self._puts = 0
+        self._evictions = 0
+
+    # ------------------------------------------------------------------ #
+    #  Internal helpers
+    # ------------------------------------------------------------------ #
+
+    def _find_free_or_evict(self) -> int:
+        """Find a FREE slot, or evict the LRU entry.  Must hold flock."""
+        min_tick = np.iinfo(np.int64).max
+        min_idx = 0
+        for i in range(self.capacity):
+            if self._entries[i]['state'] == _STATE_FREE:
+                return i
+            if self._entries[i]['access_tick'] < min_tick:
+                min_tick = int(self._entries[i]['access_tick'])
+                min_idx = i
+
+        # Evict the LRU slot.  Do NOT unlink the shm block here -- workers
+        # don't know which blocks the main process still needs.  The main
+        # process cleans up orphans in get_batch() -> _unlink_orphans().
+        self._entries[min_idx]['state'] = _STATE_FREE
+        self._evictions += 1
+        return min_idx
+
+    def _unlink_orphans(self):
+        """Unlink shm blocks that were evicted but not yet cleaned up.
+
+        Called under flock by :meth:`get_batch`.  Scans ``/dev/shm`` for
+        blocks belonging to this store that are no longer in the metadata
+        table.
+        """
+        # Active shm names from metadata table
+        active_names = set()
+        for i in range(self.capacity):
+            if self._entries[i]['state'] == _STATE_USED:
+                name = self._entries[i]['shm_name'].decode()
+                if name:
+                    active_names.add(name)
+
+        # Scan /dev/shm and unlink orphans
+        prefix = f"{_SHM_PREFIX}_{self.store_id}_"
+        for path in glob_mod.glob(f"/dev/shm/{prefix}*"):
+            name = os.path.basename(path)
+            if name not in active_names:
+                # Close our cached handle if any
+                if name in self._local_shm_handles:
+                    _force_close_shm(self._local_shm_handles[name])
+                    del self._local_shm_handles[name]
+                # Unlink the orphan
+                try:
+                    shm = shared_memory.SharedMemory(name=name, create=False)
+                    shm.close()
+                    shm.unlink()
+                except FileNotFoundError:
+                    pass
+
+    # ------------------------------------------------------------------ #
+    #  Lifecycle
+    # ------------------------------------------------------------------ #
+
+    def cleanup(self) -> None:
+        """Unlink **all** SharedMemory blocks and the lock file.
+
+        Call from the main process on shutdown.
+        """
+        # Close local handles (may have live numpy views -> _force_close_shm)
+        for shm in self._local_shm_handles.values():
+            _force_close_shm(shm)
+        self._local_shm_handles.clear()
+
+        # Glob-clean ALL shm blocks for this store (catches orphans)
+        prefix = f"{_SHM_PREFIX}_{self.store_id}_"
+        for path in glob_mod.glob(f"/dev/shm/{prefix}*"):
+            name = os.path.basename(path)
+            try:
+                shm = shared_memory.SharedMemory(name=name, create=False)
+                shm.close()
+                shm.unlink()
+            except FileNotFoundError:
+                pass
+
+        # Unlink meta and tick SharedMemory
+        _force_close_shm(self._meta_shm)
+        _force_close_shm(self._tick_shm)
+        if self._is_creator:
+            try:
+                self._meta_shm.unlink()
+            except FileNotFoundError:
+                pass
+            try:
+                self._tick_shm.unlink()
+            except FileNotFoundError:
+                pass
+            try:
+                os.close(self._lock_fd)
+                os.unlink(self._lock_path)
+            except OSError:
+                pass
+
+    def close(self) -> None:
+        """Close SharedMemory handles **without** unlinking.
+
+        Call from worker processes before exit.
+        """
+        for shm in self._local_shm_handles.values():
+            _force_close_shm(shm)
+        self._local_shm_handles.clear()
+
+        _force_close_shm(self._meta_shm)
+        _force_close_shm(self._tick_shm)
+        try:
+            os.close(self._lock_fd)
+        except OSError:
+            pass
+
+
+# ---------------------------------------------------------------------------
+# Module-private helpers
+# ---------------------------------------------------------------------------
+
+def _force_close_shm(shm) -> None:
+    """Close a SharedMemory handle, suppressing BufferError from live numpy views.
+
+    When ``np.frombuffer(shm.buf)`` creates a zero-copy view, the numpy
+    array holds a reference to the underlying mmap.  ``shm.close()`` then
+    raises ``BufferError: cannot close exported pointers exist``.
+
+    We catch this, then clear the internal ``_mmap`` and ``_buf`` attributes
+    so that ``SharedMemory.__del__`` (called later by GC) does not re-raise
+    the same error.  The actual backing memory is freed by the OS when the
+    last numpy view is garbage-collected.
+    """
+    try:
+        shm.close()
+    except BufferError:
+        # Prevent __del__ from retrying and printing the same traceback.
+        shm._buf = None
+        shm._mmap = None
+    except Exception:
+        pass
+
+
+def _cleanup_stale_shm(name: str) -> None:
+    """Remove a SharedMemory block left over from a previous run."""
+    try:
+        stale = shared_memory.SharedMemory(name=name, create=False)
+        stale.close()
+        stale.unlink()
+    except FileNotFoundError:
+        pass

--- a/packages/on_demand_video_decoder/accvlab/on_demand_video_decoder/_internal/shared_gop_store.py
+++ b/packages/on_demand_video_decoder/accvlab/on_demand_video_decoder/_internal/shared_gop_store.py
@@ -15,9 +15,10 @@
 """
 SharedGopStore: Cross-process shared GOP store backed by POSIX SharedMemory.
 
-Workers ``put()`` GOP packet data and pass lightweight :class:`GopRef`
-references through the DataLoader IPC queue.  The main process
-``get_batch()`` to read references as zero-copy numpy views.
+Workers :meth:`SharedGopStore.put` GOP packet data and pass lightweight
+:class:`GopRef` references through the DataLoader IPC queue.  The main
+process calls :meth:`SharedGopStore.get_batch` to read references as
+zero-copy numpy views.
 
 Synchronization uses file-based locking (``flock``) which works across
 ``spawn``'d DataLoader workers (unlike ``multiprocessing.Lock``).
@@ -77,6 +78,10 @@ _STATE_USED = np.uint8(1)
 # SharedMemory name prefix used for GOP data blocks.
 _SHM_PREFIX = "gs"
 
+# Private key to prevent direct instantiation of SharedGopStore.
+# Mirrors the pattern used by ``CachedGopDecoder`` in ``_internal/decoder.py``.
+_CREATION_KEY = object()
+
 
 def _hash_video_path(video_path: str) -> np.uint64:
     """Deterministic uint64 hash for a video path string.
@@ -105,13 +110,29 @@ class SharedGopStore:
 
     A recommended formula is ``batch_size * num_cameras * 10``.
 
+    Note:
+        Do not instantiate this class directly.
+        Use :meth:`create` (main process, before spawning workers) or
+        :meth:`attach` (worker processes) instead — these factories
+        manage shared-memory creation and tear-down correctly.
+
     Args:
         capacity: Maximum number of GOPs to cache.
         store_id: Unique identifier (typically ``LOCAL_RANK``).
         _create: Internal flag -- use :meth:`create` / :meth:`attach`.
+
+    Raises:
+        RuntimeError: If called directly instead of via :meth:`create` /
+            :meth:`attach`.
     """
 
-    def __init__(self, capacity: int, store_id: int, _create: bool):
+    def __init__(self, capacity: int, store_id: int, _create: bool, *, _key=None):
+        if _key is not _CREATION_KEY:
+            raise RuntimeError(
+                "SharedGopStore cannot be instantiated directly. "
+                "Use SharedGopStore.create() (main process) or "
+                "SharedGopStore.attach() (workers) instead."
+            )
         self.capacity = capacity
         self.store_id = store_id
         self._is_creator = _create
@@ -173,7 +194,7 @@ class SharedGopStore:
             capacity: Max number of GOPs to cache.
             store_id: Unique identifier (typically ``LOCAL_RANK``).
         """
-        return cls(capacity=capacity, store_id=store_id, _create=True)
+        return cls(capacity=capacity, store_id=store_id, _create=True, _key=_CREATION_KEY)
 
     @classmethod
     def attach(cls, capacity: int, store_id: int = 0) -> 'SharedGopStore':
@@ -182,7 +203,7 @@ class SharedGopStore:
         Raises:
             FileNotFoundError: If the store has not been created yet.
         """
-        return cls(capacity=capacity, store_id=store_id, _create=False)
+        return cls(capacity=capacity, store_id=store_id, _create=False, _key=_CREATION_KEY)
 
     # ------------------------------------------------------------------ #
     #  Locking helpers (flock)

--- a/packages/on_demand_video_decoder/accvlab/on_demand_video_decoder/_internal/types.py
+++ b/packages/on_demand_video_decoder/accvlab/on_demand_video_decoder/_internal/types.py
@@ -17,6 +17,27 @@ Type definitions and enumerations for the video decoder module.
 """
 
 from enum import Enum
+from typing import NamedTuple
+
+
+class GopRef(NamedTuple):
+    """Lightweight, picklable reference to GOP data in shared memory.
+
+    Designed to be passed through DataLoader IPC queues (tens of bytes)
+    instead of the actual GOP packet data (tens of KB).  The main process
+    calls ``SharedGopStore.get_batch()`` to read the referenced shm blocks
+    as zero-copy numpy views.
+
+    Attributes:
+        shm_name: POSIX SharedMemory name for the data block.
+        data_size: Number of bytes of GOP packet data.
+        first_frame_id: First frame index covered by this GOP.
+        gop_len: Number of frames in this GOP.
+    """
+    shm_name: str
+    data_size: int
+    first_frame_id: int
+    gop_len: int
 
 
 class Codec(Enum):

--- a/packages/on_demand_video_decoder/accvlab/on_demand_video_decoder/_internal/types.py
+++ b/packages/on_demand_video_decoder/accvlab/on_demand_video_decoder/_internal/types.py
@@ -34,6 +34,7 @@ class GopRef(NamedTuple):
         first_frame_id: First frame index covered by this GOP.
         gop_len: Number of frames in this GOP.
     """
+
     shm_name: str
     data_size: int
     first_frame_id: int

--- a/packages/on_demand_video_decoder/docs/sample.md
+++ b/packages/on_demand_video_decoder/docs/sample.md
@@ -25,6 +25,7 @@ section helps you quickly locate the sample code that matches your requirements.
 | [SampleDecodeFromGopFilesToListAPI.py](../samples/SampleDecodeFromGopFilesToListAPI.py) | Selective GOP loading | {py:meth}`~accvlab.on_demand_video_decoder.PyNvGopDecoder.LoadGopsToList`, {py:meth}`~accvlab.on_demand_video_decoder.PyNvGopDecoder.DecodeFromGOPListRGB` |
 | [SampleDecodeFromGopList.py](../samples/SampleDecodeFromGopList.py) | Batch decode from multiple demux results (N demux → 1 decode) | {py:meth}`~accvlab.on_demand_video_decoder.PyNvGopDecoder.DecodeFromGOPListRGB` |
 | [SampleStreamAsyncAccess.py](../samples/SampleStreamAsyncAccess.py) | Async stream decoding with prefetching | {py:func}`~accvlab.on_demand_video_decoder.CreateSampleReader`, {py:meth}`~accvlab.on_demand_video_decoder.PyNvSampleReader.DecodeN12ToRGBAsync`, {py:meth}`~accvlab.on_demand_video_decoder.PyNvSampleReader.DecodeN12ToRGBAsyncGetBuffer` |
+| [SampleSharedGopStore.py](../samples/SampleSharedGopStore.py) | Cross-process shared GOP cache for DataLoader | {py:class}`~accvlab.on_demand_video_decoder.SharedGopStore`, {py:class}`~accvlab.on_demand_video_decoder.GopRef` |
 
 For details on the **Key APIs**, please refer to the API documentation of the corresponding functions and classes.
 
@@ -59,6 +60,10 @@ If you need to save GOP data to disk:
 If you need to batch decode from multiple separate demux operations:
     (e.g., DataLoader workers demux in parallel, main process batch decode)
     → Use SampleDecodeFromGopList
+
+If you need cross-process shared GOP caching for DataLoader workers:
+    (e.g., workers demux GOPs into shared memory, main process reads zero-copy)
+    → Use SampleSharedGopStore
 ```
 
 ### 1.3 Core Concepts
@@ -76,6 +81,8 @@ Before diving into the samples, understanding these concepts will be helpful:
 - **FastInit**: An optimization technique that caches stream metadata to accelerate decoder initialization for multiple clips with similar properties.
 
 - **GOP Caching**: A Python-side caching mechanism that stores extracted GOP data in memory. When the same video file is requested with a `frame_id` that falls within an already cached GOP range, the cached data is returned directly without re-demuxing from the video file.
+
+- **SharedGopStore**: A cross-process shared memory cache for GOP data, backed by POSIX SharedMemory (`/dev/shm`). Workers store GOP packets in shared memory and pass lightweight `GopRef` references through the DataLoader IPC queue. The main process reads the data as zero-copy numpy views via `get_batch()`. Uses file-based locking (`flock`) for cross-process safety and LRU eviction when capacity is exceeded.
 
 ## 2. Quick Start
 
@@ -1291,4 +1298,196 @@ def collate_fn(batch):
 ```bash
 cd packages/on_demand_video_decoder/samples
 python SampleDecodeFromGopList.py
+```
+
+### 3.5 Shared GOP Store
+
+SharedGopStore provides a cross-process shared memory cache for GOP packet data, designed for PyTorch 
+DataLoader integration. Workers store demuxed GOP data in POSIX shared memory and pass lightweight `GopRef` 
+references through the IPC queue, while the main process reads the data as zero-copy numpy views.
+
+#### 3.5.1 Use Cases
+
+- Multi-worker DataLoader with separation access (workers demux, main process decodes on GPU)
+- Multi-camera setups where different workers may request overlapping GOPs
+- Reducing redundant demuxing when multiple workers access the same video segment
+- Training pipelines that need to pass GOP data from workers to main process efficiently
+
+#### 3.5.2 Architecture
+
+```
+Main Process                     Worker Processes
+─────────────                    ────────────────
+SharedGopStore.create()
+    │
+    ├──spawn──> Worker 0: SharedGopStore.attach()
+    │               lookup(video, frame_id)
+    │                 ├─ HIT  → return GopRef
+    │                 └─ MISS → demux from disk
+    │                          put(video, data) → GopRef
+    │               queue.put(GopRef)  ← tens of bytes
+    │
+    ├──spawn──> Worker 1: (same pattern)
+    │               ...
+    │
+    ◄── queue.get() ── [GopRef, GopRef, ...]
+    │
+    get_batch(refs)  ← zero-copy numpy views
+    │
+    DecodeFromGOPListRGB(...)  ← GPU decode
+    │
+    cleanup()  ← unlink all shm blocks
+```
+
+#### 3.5.3 Sample: SharedGopStore
+
+**File:** `packages/on_demand_video_decoder/samples/SampleSharedGopStore.py`
+
+> **ℹ️ Note**: This sample is a pure CPU / shared-memory demo. No GPU or video files are required — 
+> GOP data is simulated with random bytes.
+
+**Core APIs**
+
+- {py:class}`~accvlab.on_demand_video_decoder.SharedGopStore`: Cross-process shared memory GOP cache
+  - `create(capacity, store_id)`: Allocate a new store (main process)
+  - `attach(capacity, store_id)`: Attach to existing store (worker processes)
+  - `lookup(video_path, frame_id)`: Lock-free cache lookup, returns `GopRef` or `None`
+  - `put(video_path, first_frame_id, gop_len, data)`: Store GOP data, returns `GopRef`
+  - `get_batch(refs)`: Read a batch of `GopRef` as zero-copy numpy views (main process)
+  - `read(ref)`: Read a single `GopRef` as a zero-copy numpy view
+  - `cleanup()`: Unlink all shared memory blocks (main process, on shutdown)
+  - `close()`: Close handles without unlinking (worker processes, before exit)
+- {py:class}`~accvlab.on_demand_video_decoder.GopRef`: Lightweight, picklable reference to GOP data in 
+  shared memory (passed through DataLoader IPC queue)
+
+**Code Walkthrough**
+
+**Step 1: Main process creates the store before spawning workers**
+
+```python
+from accvlab.on_demand_video_decoder import SharedGopStore
+
+STORE_ID = 0       # typically LOCAL_RANK
+CAPACITY = 120     # must exceed in-flight GOPs (see sizing below)
+
+store = SharedGopStore.create(capacity=CAPACITY, store_id=STORE_ID)
+```
+
+**Step 2: Worker processes attach and perform lookup/put**
+
+```python
+def worker_fn(store_id, capacity, tasks, result_queue):
+    store = SharedGopStore.attach(capacity=capacity, store_id=store_id)
+
+    refs = []
+    for video_path, frame_id, gop_first_frame, gop_len in tasks:
+        # Lock-free lookup
+        ref = store.lookup(video_path, frame_id)
+        if ref is None:
+            # Cache miss: demux from disk (or simulate)
+            gop_data = demux_gop_from_video(video_path, frame_id)
+            ref = store.put(video_path, gop_first_frame, gop_len, gop_data)
+        refs.append(ref)
+
+    # Send lightweight refs (tens of bytes each) through IPC queue
+    result_queue.put(refs)
+    store.close()
+```
+
+**Step 3: Main process reads zero-copy data and decodes**
+
+```python
+# Collect refs from all workers
+all_refs = queue_a.get() + queue_b.get()
+
+# Read shared memory blocks as zero-copy numpy views
+arrays = store.get_batch(all_refs)
+
+# Decode on GPU
+decoded_frames = decoder.DecodeFromGOPListRGB(arrays, file_paths, frame_ids, True)
+```
+
+**Step 4: Cleanup on shutdown**
+
+```python
+store.cleanup()  # unlinks all /dev/shm blocks for this store
+```
+
+**Capacity Sizing**
+
+The `capacity` parameter must exceed the maximum number of GOPs that can be "in flight" (queued in the 
+DataLoader + being consumed by the training loop):
+
+```
+min_capacity > (prefetch_factor * num_workers + 1) * batch_size * num_cameras
+```
+
+A recommended formula is:
+
+```python
+capacity = batch_size * num_cameras * 10
+```
+
+If capacity is too small, GOPs may be evicted before the main process can read them. In this case, 
+`read()` returns a zeros array and emits a `RuntimeWarning` with diagnostic information instead of 
+crashing.
+
+**GopRef IPC Efficiency**
+
+`GopRef` is a `NamedTuple` with 4 fields (shm_name, data_size, first_frame_id, gop_len). It serializes 
+to ~60 bytes via pickle, compared to ~4-40 KB for the actual GOP packet data. This makes DataLoader IPC 
+overhead negligible.
+
+```python
+import pickle
+from accvlab.on_demand_video_decoder import GopRef
+
+ref = GopRef(shm_name="gs_0_12345_0", data_size=4096, first_frame_id=0, gop_len=30)
+print(len(pickle.dumps(ref)))  # ~60 bytes
+```
+
+**LRU Eviction**
+
+When the store is full, `put()` evicts the least-recently-used entry (lowest `access_tick`). Both 
+`lookup()` and `put()` refresh an entry's tick, so frequently accessed GOPs are retained. Evicted shm 
+blocks are cleaned up during the next `get_batch()` call.
+
+**Cross-Process Safety**
+
+- `lookup()` is lock-free (worst case: stale miss, one extra disk read)
+- `put()` acquires an `flock` for atomicity (double-check after acquiring the lock)
+- `get_batch()` acquires an `flock` to prevent eviction while opening handles
+- Works with `spawn`'d DataLoader workers (unlike `multiprocessing.Lock`)
+
+**Running the Sample**
+
+```bash
+cd packages/on_demand_video_decoder/samples
+python SampleSharedGopStore.py
+```
+
+Expected output:
+
+```text
+SharedGopStore Demo
+============================================================
+
+[Main] Creating SharedGopStore (capacity=12, store_id=0)
+
+[Main] Spawning 2 workers...
+  [Worker 12345] Attached to store (id=0, capacity=12)
+  [Worker 12345] MISS /data/video/cam0.mp4 frame=15 -> put as gs_0_...
+  ...
+  [Worker 12346] HIT  /data/video/cam0.mp4 frame=20
+  ...
+
+[Main] Received 12 GopRef references from workers
+[Main] GopRef size: 60 bytes (vs ~4096 bytes of actual GOP data)
+
+[Main] Got 12 zero-copy numpy views:
+  [0] shape=(4096,), dtype=uint8, nbytes=4096
+  ...
+
+[Main] Cleanup complete. All shared memory released.
+[Main] Verified: no shared memory files leaked.
 ```

--- a/packages/on_demand_video_decoder/docs/sample.md
+++ b/packages/on_demand_video_decoder/docs/sample.md
@@ -1349,15 +1349,21 @@ SharedGopStore.create()
 **Core APIs**
 
 - {py:class}`~accvlab.on_demand_video_decoder.SharedGopStore`: Cross-process shared memory GOP cache
-  - `create(capacity, store_id)`: Allocate a new store (main process)
-  - `attach(capacity, store_id)`: Attach to existing store (worker processes)
-  - `lookup(video_path, frame_id)`: Lock-free cache lookup, returns `GopRef` or `None`
-  - `put(video_path, first_frame_id, gop_len, data)`: Store GOP data, returns `GopRef`
-  - `get_batch(refs)`: Read a batch of `GopRef` as zero-copy numpy views (main process)
-  - `read(ref)`: Read a single `GopRef` as a zero-copy numpy view
-  - `cleanup()`: Unlink all shared memory blocks (main process, on shutdown)
-  - `close()`: Close handles without unlinking (worker processes, before exit)
-- {py:class}`~accvlab.on_demand_video_decoder.GopRef`: Lightweight, picklable reference to GOP data in 
+  - {py:meth}`~accvlab.on_demand_video_decoder.SharedGopStore.create`: Allocate a new store (main process)
+  - {py:meth}`~accvlab.on_demand_video_decoder.SharedGopStore.attach`: Attach to existing store (worker processes)
+  - {py:meth}`~accvlab.on_demand_video_decoder.SharedGopStore.lookup`: Lock-free cache lookup, returns
+    {py:class}`~accvlab.on_demand_video_decoder.GopRef` or ``None``
+  - {py:meth}`~accvlab.on_demand_video_decoder.SharedGopStore.put`: Store GOP data, returns
+    {py:class}`~accvlab.on_demand_video_decoder.GopRef`
+  - {py:meth}`~accvlab.on_demand_video_decoder.SharedGopStore.get_batch`: Read a batch of
+    {py:class}`~accvlab.on_demand_video_decoder.GopRef` as zero-copy numpy views (main process)
+  - {py:meth}`~accvlab.on_demand_video_decoder.SharedGopStore.read`: Read a single
+    {py:class}`~accvlab.on_demand_video_decoder.GopRef` as a zero-copy numpy view
+  - {py:meth}`~accvlab.on_demand_video_decoder.SharedGopStore.cleanup`: Unlink all shared memory blocks
+    (main process, on shutdown)
+  - {py:meth}`~accvlab.on_demand_video_decoder.SharedGopStore.close`: Close handles without unlinking
+    (worker processes, before exit)
+- {py:class}`~accvlab.on_demand_video_decoder.GopRef`: Lightweight, picklable reference to GOP data in
   shared memory (passed through DataLoader IPC queue)
 
 **Code Walkthrough**
@@ -1397,7 +1403,9 @@ def worker_fn(store_id, capacity, tasks, result_queue):
 **Step 3: Main process reads zero-copy data and decodes**
 
 ```python
-# Collect refs from all workers
+# `queue_a` and `queue_b` are the IPC queues belonging to two separate
+# DataLoader workers spawned in Step 2. Each worker pushes its own list
+# of GopRefs onto its own queue; the main process gathers them here.
 all_refs = queue_a.get() + queue_b.get()
 
 # Read shared memory blocks as zero-copy numpy views
@@ -1428,15 +1436,15 @@ A recommended formula is:
 capacity = batch_size * num_cameras * 10
 ```
 
-If capacity is too small, GOPs may be evicted before the main process can read them. In this case, 
-`read()` returns a zeros array and emits a `RuntimeWarning` with diagnostic information instead of 
-crashing.
+If capacity is too small, GOPs may be evicted before the main process can read them. In this case,
+{py:meth}`~accvlab.on_demand_video_decoder.SharedGopStore.read` returns a zeros array and emits a
+`RuntimeWarning` with diagnostic information instead of crashing.
 
 **GopRef IPC Efficiency**
 
-`GopRef` is a `NamedTuple` with 4 fields (shm_name, data_size, first_frame_id, gop_len). It serializes 
-to ~60 bytes via pickle, compared to ~4-40 KB for the actual GOP packet data. This makes DataLoader IPC 
-overhead negligible.
+{py:class}`~accvlab.on_demand_video_decoder.GopRef` is a `NamedTuple` with 4 fields (shm_name, data_size,
+first_frame_id, gop_len). It serializes to ~60 bytes via pickle, compared to ~4-40 KB for the actual GOP
+packet data. This makes DataLoader IPC overhead negligible.
 
 ```python
 import pickle
@@ -1448,15 +1456,18 @@ print(len(pickle.dumps(ref)))  # ~60 bytes
 
 **LRU Eviction**
 
-When the store is full, `put()` evicts the least-recently-used entry (lowest `access_tick`). Both 
-`lookup()` and `put()` refresh an entry's tick, so frequently accessed GOPs are retained. Evicted shm 
-blocks are cleaned up during the next `get_batch()` call.
+When the store is full, {py:meth}`~accvlab.on_demand_video_decoder.SharedGopStore.put` evicts the
+least-recently-used entry (lowest `access_tick`). Both
+{py:meth}`~accvlab.on_demand_video_decoder.SharedGopStore.lookup` and
+{py:meth}`~accvlab.on_demand_video_decoder.SharedGopStore.put` refresh an entry's tick, so frequently
+accessed GOPs are retained. Evicted shm blocks are cleaned up during the next
+{py:meth}`~accvlab.on_demand_video_decoder.SharedGopStore.get_batch` call.
 
 **Cross-Process Safety**
 
-- `lookup()` is lock-free (worst case: stale miss, one extra disk read)
-- `put()` acquires an `flock` for atomicity (double-check after acquiring the lock)
-- `get_batch()` acquires an `flock` to prevent eviction while opening handles
+- {py:meth}`~accvlab.on_demand_video_decoder.SharedGopStore.lookup` is lock-free (worst case: stale miss, one extra disk read)
+- {py:meth}`~accvlab.on_demand_video_decoder.SharedGopStore.put` acquires an `flock` for atomicity
+- {py:meth}`~accvlab.on_demand_video_decoder.SharedGopStore.get_batch` acquires an `flock` to prevent eviction while opening handles
 - Works with `spawn`'d DataLoader workers (unlike `multiprocessing.Lock`)
 
 **Running the Sample**

--- a/packages/on_demand_video_decoder/ext_impl/src/VideoCodecSDKUtils/helper_classes/Utils/FFmpegDemuxer.h
+++ b/packages/on_demand_video_decoder/ext_impl/src/VideoCodecSDKUtils/helper_classes/Utils/FFmpegDemuxer.h
@@ -366,7 +366,7 @@ class FFmpegDemuxer {
                 nBPP = 1;
                 break;
             default:
-                LOG(WARNING) << "ChromaFormat not recognized. Assuming 420";
+                // LOG(WARNING) << "ChromaFormat not recognized. Assuming 420";
                 eChromaFormat = AV_PIX_FMT_YUV420P;
                 nBitDepth = 8;
                 nChromaHeight = (nHeight + 1) >> 1;

--- a/packages/on_demand_video_decoder/ext_impl/src/VideoCodecSDKUtils/helper_classes/Utils/FFmpegDemuxer.h
+++ b/packages/on_demand_video_decoder/ext_impl/src/VideoCodecSDKUtils/helper_classes/Utils/FFmpegDemuxer.h
@@ -365,12 +365,19 @@ class FFmpegDemuxer {
                 nChromaHeight = (nHeight + 1) >> 1;
                 nBPP = 1;
                 break;
-            default:
-                // LOG(WARNING) << "ChromaFormat not recognized. Assuming 420";
+            default: {
+                // Warn on first occurrence only to avoid log spam when the
+                // same unsupported pixfmt streams in repeatedly.
+                static bool warned = false;
+                if (!warned) {
+                    LOG(WARNING) << "ChromaFormat not recognized. Assuming 420";
+                    warned = true;
+                }
                 eChromaFormat = AV_PIX_FMT_YUV420P;
                 nBitDepth = 8;
                 nChromaHeight = (nHeight + 1) >> 1;
                 nBPP = 1;
+            }
         }
 
         bMp4H264 =

--- a/packages/on_demand_video_decoder/samples/SampleSharedGopStore.py
+++ b/packages/on_demand_video_decoder/samples/SampleSharedGopStore.py
@@ -47,10 +47,10 @@ import numpy as np
 import accvlab.on_demand_video_decoder as nvc
 from accvlab.on_demand_video_decoder import GopRef, SharedGopStore
 
-
 # ---------------------------------------------------------------------------
 # Simulated worker function (runs in a spawned child process)
 # ---------------------------------------------------------------------------
+
 
 def worker_fn(store_id, capacity, tasks, result_queue):
     """
@@ -74,15 +74,16 @@ def worker_fn(store_id, capacity, tasks, result_queue):
             print(f"  [Worker {pid}] HIT  {video_path} frame={frame_id}")
         else:
             # Step 2: Cache miss -> "load from disk" (simulated with random bytes)
-            fake_gop_data = np.random.randint(
-                0, 256, size=4096, dtype=np.uint8)
+            fake_gop_data = np.random.randint(0, 256, size=4096, dtype=np.uint8)
             ref = store.put(video_path, gop_first_frame, gop_len, fake_gop_data)
             print(f"  [Worker {pid}] MISS {video_path} frame={frame_id} -> put as {ref.shm_name}")
         refs.append(ref)
 
     stats = store.get_stats()
-    print(f"  [Worker {pid}] Stats: hits={stats['hits']}, misses={stats['misses']}, "
-          f"hit_rate={stats['hit_rate']:.0%}")
+    print(
+        f"  [Worker {pid}] Stats: hits={stats['hits']}, misses={stats['misses']}, "
+        f"hit_rate={stats['hit_rate']:.0%}"
+    )
 
     # Send lightweight GopRef list through the "IPC queue"
     result_queue.put(refs)
@@ -92,6 +93,7 @@ def worker_fn(store_id, capacity, tasks, result_queue):
 # ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
+
 
 def SampleSharedGopStore():
     """
@@ -134,12 +136,12 @@ def SampleSharedGopStore():
     ]
     # Worker B requests overlapping videos -> should get cache hits
     tasks_b = [
-        ("/data/video/cam0.mp4", 20, 0, 30),   # same GOP as worker A
-        ("/data/video/cam1.mp4", 25, 0, 30),   # same GOP as worker A
-        ("/data/video/cam2.mp4", 10, 0, 30),   # same GOP as worker A
-        ("/data/video/cam6.mp4", 15, 0, 30),   # new video
-        ("/data/video/cam7.mp4", 15, 0, 30),   # new video
-        ("/data/video/cam8.mp4", 15, 0, 30),   # new video
+        ("/data/video/cam0.mp4", 20, 0, 30),  # same GOP as worker A
+        ("/data/video/cam1.mp4", 25, 0, 30),  # same GOP as worker A
+        ("/data/video/cam2.mp4", 10, 0, 30),  # same GOP as worker A
+        ("/data/video/cam6.mp4", 15, 0, 30),  # new video
+        ("/data/video/cam7.mp4", 15, 0, 30),  # new video
+        ("/data/video/cam8.mp4", 15, 0, 30),  # new video
     ]
 
     # ── 3. Spawn workers ─────────────────────────────────────────
@@ -148,10 +150,8 @@ def SampleSharedGopStore():
     queue_a = ctx.Queue()
     queue_b = ctx.Queue()
 
-    worker_a = ctx.Process(target=worker_fn,
-                           args=(STORE_ID, CAPACITY, tasks_a, queue_a))
-    worker_b = ctx.Process(target=worker_fn,
-                           args=(STORE_ID, CAPACITY, tasks_b, queue_b))
+    worker_a = ctx.Process(target=worker_fn, args=(STORE_ID, CAPACITY, tasks_a, queue_a))
+    worker_b = ctx.Process(target=worker_fn, args=(STORE_ID, CAPACITY, tasks_b, queue_b))
 
     # Start A first, wait for it, then start B (so B sees A's data)
     worker_a.start()
@@ -168,8 +168,9 @@ def SampleSharedGopStore():
     all_refs = refs_a + refs_b
 
     print(f"\n[Main] Received {len(all_refs)} GopRef references from workers")
-    print(f"[Main] GopRef size: {len(pickle.dumps(all_refs[0]))} bytes "
-          f"(vs ~4096 bytes of actual GOP data)")
+    print(
+        f"[Main] GopRef size: {len(pickle.dumps(all_refs[0]))} bytes " f"(vs ~4096 bytes of actual GOP data)"
+    )
 
     # ── 5. get_batch: read shm blocks + orphan cleanup ────────────
     print(f"\n[Main] Resolving {len(all_refs)} references (atomic open + orphan cleanup)...")
@@ -188,9 +189,12 @@ def SampleSharedGopStore():
 
     # Verify no shm files remain
     import glob
-    remaining = glob.glob(f"/dev/shm/gs_{STORE_ID}_*") + \
-                glob.glob(f"/dev/shm/gs_meta_{STORE_ID}") + \
-                glob.glob(f"/dev/shm/gs_tick_{STORE_ID}")
+
+    remaining = (
+        glob.glob(f"/dev/shm/gs_{STORE_ID}_*")
+        + glob.glob(f"/dev/shm/gs_meta_{STORE_ID}")
+        + glob.glob(f"/dev/shm/gs_tick_{STORE_ID}")
+    )
     assert not remaining, f"Leaked shm files: {remaining}"
     print("[Main] Verified: no shared memory files leaked.")
 

--- a/packages/on_demand_video_decoder/samples/SampleSharedGopStore.py
+++ b/packages/on_demand_video_decoder/samples/SampleSharedGopStore.py
@@ -1,0 +1,206 @@
+# Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+``accvlab.on_demand_video_decoder`` - SharedGopStore Sample
+
+This sample demonstrates how to use ``SharedGopStore`` for cross-process
+shared GOP caching with zero-copy reads.  It simulates the typical
+DataLoader pattern:
+
+1. **Main process** creates the store before spawning workers.
+2. **Worker processes** attach to the store, look up / put GOP data,
+   and pass lightweight ``GopRef`` references through the IPC queue.
+3. **Main process** calls ``get_batch()`` to read references as
+   zero-copy numpy views and clean up orphaned shared-memory blocks.
+
+Key Features Demonstrated:
+- Cross-process shared memory cache (POSIX shm + flock)
+- Zero-copy data access from main process
+- LRU eviction when capacity is exceeded
+- Orphan cleanup via ``get_batch()``
+- GopRef pickling for DataLoader IPC
+
+Requirements:
+- Linux (POSIX shared memory)
+- No GPU required (pure CPU / shared-memory demo)
+"""
+
+import multiprocessing
+import os
+import pickle
+import time
+
+import numpy as np
+
+import accvlab.on_demand_video_decoder as nvc
+from accvlab.on_demand_video_decoder import GopRef, SharedGopStore
+
+
+# ---------------------------------------------------------------------------
+# Simulated worker function (runs in a spawned child process)
+# ---------------------------------------------------------------------------
+
+def worker_fn(store_id, capacity, tasks, result_queue):
+    """
+    Simulate a DataLoader worker: attach to store, lookup/put, return refs.
+
+    Args:
+        store_id: SharedGopStore identifier to attach to.
+        capacity: Store capacity (must match the main process).
+        tasks: List of (video_path, frame_id, gop_first_frame, gop_len) to process.
+        result_queue: multiprocessing.Queue to send GopRef results back.
+    """
+    pid = os.getpid()
+    store = SharedGopStore.attach(capacity=capacity, store_id=store_id)
+    print(f"  [Worker {pid}] Attached to store (id={store_id}, capacity={capacity})")
+
+    refs = []
+    for video_path, frame_id, gop_first_frame, gop_len in tasks:
+        # Step 1: Try lock-free lookup
+        ref = store.lookup(video_path, frame_id)
+        if ref is not None:
+            print(f"  [Worker {pid}] HIT  {video_path} frame={frame_id}")
+        else:
+            # Step 2: Cache miss -> "load from disk" (simulated with random bytes)
+            fake_gop_data = np.random.randint(
+                0, 256, size=4096, dtype=np.uint8)
+            ref = store.put(video_path, gop_first_frame, gop_len, fake_gop_data)
+            print(f"  [Worker {pid}] MISS {video_path} frame={frame_id} -> put as {ref.shm_name}")
+        refs.append(ref)
+
+    stats = store.get_stats()
+    print(f"  [Worker {pid}] Stats: hits={stats['hits']}, misses={stats['misses']}, "
+          f"hit_rate={stats['hit_rate']:.0%}")
+
+    # Send lightweight GopRef list through the "IPC queue"
+    result_queue.put(refs)
+    store.close()
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def SampleSharedGopStore():
+    """
+    Demonstrate SharedGopStore with simulated multi-process DataLoader.
+
+    Flow:
+        Main process          Worker A            Worker B
+        ─────────────         ────────            ────────
+        create(cap=12)
+        spawn workers ──────> attach()            attach()
+                              lookup/put ──┐      lookup/put ──┐
+                              send refs    │      send refs    │
+                                           │                   │
+        receive refs <─────────────────────┘───────────────────┘
+        get_batch(refs)   ← atomic open + orphan cleanup
+        read data       ← zero-copy numpy views
+        cleanup()
+    """
+    STORE_ID = 0
+    CAPACITY = 12  # small for demo; production uses bs * cameras * 10
+    NUM_WORKERS = 2
+
+    print("=" * 60)
+    print("SharedGopStore Demo")
+    print("=" * 60)
+
+    # ── 1. Main process creates the store ────────────────────────
+    print(f"\n[Main] Creating SharedGopStore (capacity={CAPACITY}, store_id={STORE_ID})")
+    store = SharedGopStore.create(capacity=CAPACITY, store_id=STORE_ID)
+
+    # ── 2. Prepare tasks (simulating a batch of 6 cameras × 2 samples) ──
+    # Each task: (video_path, target_frame_id, gop_first_frame, gop_len)
+    tasks_a = [
+        ("/data/video/cam0.mp4", 15, 0, 30),
+        ("/data/video/cam1.mp4", 15, 0, 30),
+        ("/data/video/cam2.mp4", 15, 0, 30),
+        ("/data/video/cam3.mp4", 15, 0, 30),
+        ("/data/video/cam4.mp4", 15, 0, 30),
+        ("/data/video/cam5.mp4", 15, 0, 30),
+    ]
+    # Worker B requests overlapping videos -> should get cache hits
+    tasks_b = [
+        ("/data/video/cam0.mp4", 20, 0, 30),   # same GOP as worker A
+        ("/data/video/cam1.mp4", 25, 0, 30),   # same GOP as worker A
+        ("/data/video/cam2.mp4", 10, 0, 30),   # same GOP as worker A
+        ("/data/video/cam6.mp4", 15, 0, 30),   # new video
+        ("/data/video/cam7.mp4", 15, 0, 30),   # new video
+        ("/data/video/cam8.mp4", 15, 0, 30),   # new video
+    ]
+
+    # ── 3. Spawn workers ─────────────────────────────────────────
+    print(f"\n[Main] Spawning {NUM_WORKERS} workers...")
+    ctx = multiprocessing.get_context("spawn")
+    queue_a = ctx.Queue()
+    queue_b = ctx.Queue()
+
+    worker_a = ctx.Process(target=worker_fn,
+                           args=(STORE_ID, CAPACITY, tasks_a, queue_a))
+    worker_b = ctx.Process(target=worker_fn,
+                           args=(STORE_ID, CAPACITY, tasks_b, queue_b))
+
+    # Start A first, wait for it, then start B (so B sees A's data)
+    worker_a.start()
+    worker_a.join(timeout=30)
+    assert worker_a.exitcode == 0, f"Worker A failed with exit code {worker_a.exitcode}"
+
+    worker_b.start()
+    worker_b.join(timeout=30)
+    assert worker_b.exitcode == 0, f"Worker B failed with exit code {worker_b.exitcode}"
+
+    # ── 4. Collect GopRef results ────────────────────────────────
+    refs_a = queue_a.get(timeout=5)
+    refs_b = queue_b.get(timeout=5)
+    all_refs = refs_a + refs_b
+
+    print(f"\n[Main] Received {len(all_refs)} GopRef references from workers")
+    print(f"[Main] GopRef size: {len(pickle.dumps(all_refs[0]))} bytes "
+          f"(vs ~4096 bytes of actual GOP data)")
+
+    # ── 5. get_batch: read shm blocks + orphan cleanup ────────────
+    print(f"\n[Main] Resolving {len(all_refs)} references (atomic open + orphan cleanup)...")
+    arrays = store.get_batch(all_refs)
+
+    print(f"[Main] Got {len(arrays)} zero-copy numpy views:")
+    for i, arr in enumerate(arrays):
+        print(f"  [{i}] shape={arr.shape}, dtype={arr.dtype}, nbytes={arr.nbytes}")
+
+    # ── 6. Verify data integrity ─────────────────────────────────
+    print(f"\n[Main] Store stats: {store.get_stats()}")
+
+    # ── 7. Cleanup ───────────────────────────────────────────────
+    store.cleanup()
+    print(f"\n[Main] Cleanup complete. All shared memory released.")
+
+    # Verify no shm files remain
+    import glob
+    remaining = glob.glob(f"/dev/shm/gs_{STORE_ID}_*") + \
+                glob.glob(f"/dev/shm/gs_meta_{STORE_ID}") + \
+                glob.glob(f"/dev/shm/gs_tick_{STORE_ID}")
+    assert not remaining, f"Leaked shm files: {remaining}"
+    print("[Main] Verified: no shared memory files leaked.")
+
+    print("\n" + "=" * 60)
+    print("Demo complete.")
+    print("=" * 60)
+
+
+if __name__ == "__main__":
+    print("NVIDIA accvlab.on_demand_video_decoder - SharedGopStore Sample")
+    print("=" * 60)
+    print()
+    SampleSharedGopStore()

--- a/packages/on_demand_video_decoder/samples/SampleSharedGopStore.py
+++ b/packages/on_demand_video_decoder/samples/SampleSharedGopStore.py
@@ -125,7 +125,15 @@ def SampleSharedGopStore():
     store = SharedGopStore.create(capacity=CAPACITY, store_id=STORE_ID)
 
     # ── 2. Prepare tasks (simulating a batch of 6 cameras × 2 samples) ──
-    # Each task: (video_path, target_frame_id, gop_first_frame, gop_len)
+    # Each task tuple: (video_path, target_frame_id, gop_first_frame, gop_len).
+    #
+    # In a real pipeline, `gop_first_frame` and `gop_len` would come from a
+    # demuxer that has parsed the video index — for example, the GOP boundary
+    # containing `target_frame_id` returned by `GetGOPList` /
+    # `OnDemandVideoDecoder`. See `samples/SampleSeparationAccessGOPListAPI.py`
+    # for an end-to-end example of obtaining `first_frame_ids` and `gop_lens`
+    # from real videos. Here we hard-code 30-frame GOPs starting at frame 0
+    # to keep this demo CPU-only and free of video-file dependencies.
     tasks_a = [
         ("/data/video/cam0.mp4", 15, 0, 30),
         ("/data/video/cam1.mp4", 15, 0, 30),

--- a/packages/on_demand_video_decoder/tests/test_shared_gop_store.py
+++ b/packages/on_demand_video_decoder/tests/test_shared_gop_store.py
@@ -31,10 +31,10 @@ import pytest
 
 from accvlab.on_demand_video_decoder import GopRef, SharedGopStore
 
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
 
 def _make_gop_data(size: int = 1024, seed: int = 42) -> np.ndarray:
     """Create deterministic fake GOP packet data."""
@@ -44,10 +44,12 @@ def _make_gop_data(size: int = 1024, seed: int = 42) -> np.ndarray:
 
 def _shm_files_for_store(store_id: int):
     """List /dev/shm files belonging to a store."""
-    return glob.glob(f"/dev/shm/gs_{store_id}_*") + \
-           glob.glob(f"/dev/shm/gs_meta_{store_id}") + \
-           glob.glob(f"/dev/shm/gs_tick_{store_id}") + \
-           glob.glob(f"/dev/shm/gs_lock_{store_id}")
+    return (
+        glob.glob(f"/dev/shm/gs_{store_id}_*")
+        + glob.glob(f"/dev/shm/gs_meta_{store_id}")
+        + glob.glob(f"/dev/shm/gs_tick_{store_id}")
+        + glob.glob(f"/dev/shm/gs_lock_{store_id}")
+    )
 
 
 # Use a unique store_id range (9000+) to avoid collisions with real training.
@@ -80,13 +82,13 @@ def store(store_id):
 # GopRef serialization
 # ---------------------------------------------------------------------------
 
+
 class TestGopRef:
     """Tests for GopRef NamedTuple."""
 
     def test_pickle_roundtrip(self):
         """GopRef must survive pickle roundtrip (DataLoader IPC)."""
-        ref = GopRef(shm_name="gs_0_12345_0", data_size=1024,
-                     first_frame_id=0, gop_len=30)
+        ref = GopRef(shm_name="gs_0_12345_0", data_size=1024, first_frame_id=0, gop_len=30)
         restored = pickle.loads(pickle.dumps(ref))
         assert restored == ref
         assert type(restored) is GopRef
@@ -109,6 +111,7 @@ class TestGopRef:
 # ---------------------------------------------------------------------------
 # Basic lifecycle
 # ---------------------------------------------------------------------------
+
 
 class TestLifecycle:
     """Create -> put -> lookup -> read -> cleanup."""
@@ -154,6 +157,7 @@ class TestLifecycle:
 # Lookup boundary conditions
 # ---------------------------------------------------------------------------
 
+
 class TestLookupBoundary:
     """Frame-range boundary hit/miss."""
 
@@ -187,6 +191,7 @@ class TestLookupBoundary:
 # Put double-check
 # ---------------------------------------------------------------------------
 
+
 class TestPutDoubleCheck:
     """put() with same GOP twice should not create duplicate shm."""
 
@@ -207,6 +212,7 @@ class TestPutDoubleCheck:
 # ---------------------------------------------------------------------------
 # LRU eviction
 # ---------------------------------------------------------------------------
+
 
 class TestLRUEviction:
     """Capacity full -> oldest entry evicted."""
@@ -257,6 +263,7 @@ class TestLRUEviction:
 # get_batch + orphan cleanup
 # ---------------------------------------------------------------------------
 
+
 class TestGetBatch:
     """get_batch() reads shm blocks and cleans orphans."""
 
@@ -302,6 +309,7 @@ class TestGetBatch:
 # Capacity-too-small fallback (evicted before read)
 # ---------------------------------------------------------------------------
 
+
 class TestCapacityTooSmall:
     """read() returns zeros + RuntimeWarning when shm block was evicted."""
 
@@ -320,6 +328,7 @@ class TestCapacityTooSmall:
             orphan_path = f"/dev/shm/{ref0.shm_name}"
             if os.path.exists(orphan_path):
                 from multiprocessing import shared_memory
+
                 shm = shared_memory.SharedMemory(name=ref0.shm_name, create=False)
                 shm.close()
                 shm.unlink()
@@ -361,6 +370,7 @@ class TestCapacityTooSmall:
             orphan_path = f"/dev/shm/{ref0.shm_name}"
             if os.path.exists(orphan_path):
                 from multiprocessing import shared_memory
+
                 shm = shared_memory.SharedMemory(name=ref0.shm_name, create=False)
                 shm.close()
                 shm.unlink()
@@ -386,6 +396,7 @@ class TestCapacityTooSmall:
 # attach errors
 # ---------------------------------------------------------------------------
 
+
 class TestAttachErrors:
 
     def test_attach_nonexistent_raises(self):
@@ -397,6 +408,7 @@ class TestAttachErrors:
 # ---------------------------------------------------------------------------
 # Multiple stores isolation
 # ---------------------------------------------------------------------------
+
 
 class TestStoreIsolation:
     """Different store_ids do not interfere."""
@@ -434,16 +446,19 @@ class TestStoreIsolation:
 # Cross-process test (spawn mode)
 # ---------------------------------------------------------------------------
 
+
 def _worker_fn(store_id, capacity, video_path, first_frame_id, gop_len, data_bytes, result_queue):
     """Worker process: attach to store, put data, lookup, send result back."""
     store = SharedGopStore.attach(capacity=capacity, store_id=store_id)
     data = np.frombuffer(data_bytes, dtype=np.uint8)
     ref = store.put(video_path, first_frame_id, gop_len, data)
     hit = store.lookup(video_path, first_frame_id)
-    result_queue.put({
-        'ref': ref,
-        'hit': hit,
-    })
+    result_queue.put(
+        {
+            'ref': ref,
+            'hit': hit,
+        }
+    )
     store.close()
 
 
@@ -492,14 +507,15 @@ class TestCrossProcess:
 # Statistics
 # ---------------------------------------------------------------------------
 
+
 class TestStats:
     """get_stats / reset_stats correctness."""
 
     def test_stats_after_operations(self, store):
         store.put("/v.mp4", 0, 30, _make_gop_data(256))
 
-        store.lookup("/v.mp4", 15)   # hit
-        store.lookup("/v.mp4", 15)   # hit
+        store.lookup("/v.mp4", 15)  # hit
+        store.lookup("/v.mp4", 15)  # hit
         store.lookup("/other.mp4", 0)  # miss
 
         stats = store.get_stats()

--- a/packages/on_demand_video_decoder/tests/test_shared_gop_store.py
+++ b/packages/on_demand_video_decoder/tests/test_shared_gop_store.py
@@ -1,0 +1,531 @@
+# Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Tests for SharedGopStore: cross-process shared GOP store.
+
+These tests exercise the pure-Python shared memory layer.
+No GPU, CUDA, or video files required -- runs on any Linux machine.
+"""
+
+import glob
+import multiprocessing
+import os
+import pickle
+import sys
+import warnings
+
+import numpy as np
+import pytest
+
+from accvlab.on_demand_video_decoder import GopRef, SharedGopStore
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_gop_data(size: int = 1024, seed: int = 42) -> np.ndarray:
+    """Create deterministic fake GOP packet data."""
+    rng = np.random.RandomState(seed)
+    return rng.randint(0, 256, size=size, dtype=np.uint8)
+
+
+def _shm_files_for_store(store_id: int):
+    """List /dev/shm files belonging to a store."""
+    return glob.glob(f"/dev/shm/gs_{store_id}_*") + \
+           glob.glob(f"/dev/shm/gs_meta_{store_id}") + \
+           glob.glob(f"/dev/shm/gs_tick_{store_id}") + \
+           glob.glob(f"/dev/shm/gs_lock_{store_id}")
+
+
+# Use a unique store_id range (9000+) to avoid collisions with real training.
+_BASE_STORE_ID = 9000
+
+
+@pytest.fixture
+def store_id(request):
+    """Provide a unique store_id per test and clean up afterwards."""
+    # Use test index as offset to avoid collisions between parallel tests.
+    sid = _BASE_STORE_ID + hash(request.node.name) % 500
+    yield sid
+    # Best-effort cleanup: remove any leftover shm files.
+    for path in _shm_files_for_store(sid):
+        try:
+            os.unlink(path)
+        except OSError:
+            pass
+
+
+@pytest.fixture
+def store(store_id):
+    """Create a SharedGopStore, yield it, then cleanup."""
+    s = SharedGopStore.create(capacity=8, store_id=store_id)
+    yield s
+    s.cleanup()
+
+
+# ---------------------------------------------------------------------------
+# GopRef serialization
+# ---------------------------------------------------------------------------
+
+class TestGopRef:
+    """Tests for GopRef NamedTuple."""
+
+    def test_pickle_roundtrip(self):
+        """GopRef must survive pickle roundtrip (DataLoader IPC)."""
+        ref = GopRef(shm_name="gs_0_12345_0", data_size=1024,
+                     first_frame_id=0, gop_len=30)
+        restored = pickle.loads(pickle.dumps(ref))
+        assert restored == ref
+        assert type(restored) is GopRef
+
+    def test_fields(self):
+        """GopRef fields are accessible by name."""
+        ref = GopRef("name", 100, 10, 30)
+        assert ref.shm_name == "name"
+        assert ref.data_size == 100
+        assert ref.first_frame_id == 10
+        assert ref.gop_len == 30
+
+    def test_immutable(self):
+        """GopRef is immutable (NamedTuple)."""
+        ref = GopRef("name", 100, 10, 30)
+        with pytest.raises(AttributeError):
+            ref.shm_name = "other"
+
+
+# ---------------------------------------------------------------------------
+# Basic lifecycle
+# ---------------------------------------------------------------------------
+
+class TestLifecycle:
+    """Create -> put -> lookup -> read -> cleanup."""
+
+    def test_put_and_lookup_hit(self, store):
+        """Put data, then lookup by a frame_id in range."""
+        data = _make_gop_data(2048, seed=1)
+        ref = store.put("/video/cam0.mp4", first_frame_id=0, gop_len=30, data=data)
+
+        assert isinstance(ref, GopRef)
+        assert ref.data_size == 2048
+        assert ref.first_frame_id == 0
+        assert ref.gop_len == 30
+
+        # Lookup with frame_id inside [0, 30)
+        hit = store.lookup("/video/cam0.mp4", frame_id=15)
+        assert hit is not None
+        assert hit.shm_name == ref.shm_name
+
+    def test_lookup_miss(self, store):
+        """Lookup with no data returns None."""
+        assert store.lookup("/nonexistent.mp4", 0) is None
+
+    def test_read_returns_correct_data(self, store):
+        """read() returns zero-copy view matching the original data."""
+        data = _make_gop_data(4096, seed=7)
+        ref = store.put("/video/cam1.mp4", 60, 30, data)
+        view = store.read(ref)
+        np.testing.assert_array_equal(view, data)
+
+    def test_cleanup_removes_all_shm(self, store_id):
+        """After cleanup(), no shm files remain for this store."""
+        s = SharedGopStore.create(capacity=4, store_id=store_id)
+        s.put("/v.mp4", 0, 30, _make_gop_data(512))
+        s.put("/v.mp4", 30, 30, _make_gop_data(512, seed=2))
+        s.cleanup()
+
+        remaining = _shm_files_for_store(store_id)
+        assert remaining == [], f"Leaked shm files: {remaining}"
+
+
+# ---------------------------------------------------------------------------
+# Lookup boundary conditions
+# ---------------------------------------------------------------------------
+
+class TestLookupBoundary:
+    """Frame-range boundary hit/miss."""
+
+    def test_hit_at_first_frame(self, store):
+        """frame_id == first_frame_id is a hit."""
+        store.put("/v.mp4", first_frame_id=10, gop_len=20, data=_make_gop_data(256))
+        assert store.lookup("/v.mp4", 10) is not None
+
+    def test_hit_at_last_frame(self, store):
+        """frame_id == first_frame_id + gop_len - 1 is a hit."""
+        store.put("/v.mp4", first_frame_id=10, gop_len=20, data=_make_gop_data(256))
+        assert store.lookup("/v.mp4", 29) is not None
+
+    def test_miss_just_past_end(self, store):
+        """frame_id == first_frame_id + gop_len is a miss."""
+        store.put("/v.mp4", first_frame_id=10, gop_len=20, data=_make_gop_data(256))
+        assert store.lookup("/v.mp4", 30) is None
+
+    def test_miss_before_start(self, store):
+        """frame_id < first_frame_id is a miss."""
+        store.put("/v.mp4", first_frame_id=10, gop_len=20, data=_make_gop_data(256))
+        assert store.lookup("/v.mp4", 9) is None
+
+    def test_different_video_same_range(self, store):
+        """Different video_path is a miss even if frame_id is in range."""
+        store.put("/v1.mp4", first_frame_id=0, gop_len=30, data=_make_gop_data(256))
+        assert store.lookup("/v2.mp4", 15) is None
+
+
+# ---------------------------------------------------------------------------
+# Put double-check
+# ---------------------------------------------------------------------------
+
+class TestPutDoubleCheck:
+    """put() with same GOP twice should not create duplicate shm."""
+
+    def test_double_put_returns_same_ref(self, store):
+        data = _make_gop_data(1024)
+        ref1 = store.put("/v.mp4", 0, 30, data)
+        ref2 = store.put("/v.mp4", 0, 30, data)
+        assert ref1.shm_name == ref2.shm_name
+
+    def test_double_put_no_extra_slots(self, store):
+        data = _make_gop_data(1024)
+        store.put("/v.mp4", 0, 30, data)
+        store.put("/v.mp4", 0, 30, data)
+        stats = store.get_stats()
+        assert stats['puts'] == 1, "Second put should be a no-op"
+
+
+# ---------------------------------------------------------------------------
+# LRU eviction
+# ---------------------------------------------------------------------------
+
+class TestLRUEviction:
+    """Capacity full -> oldest entry evicted."""
+
+    def test_eviction_when_full(self, store_id):
+        """Fill capacity=4, then insert a 5th -> oldest evicted."""
+        store = SharedGopStore.create(capacity=4, store_id=store_id)
+        try:
+            # Fill 4 slots
+            for i in range(4):
+                store.put(f"/v{i}.mp4", 0, 30, _make_gop_data(256, seed=i))
+
+            # All 4 should be findable
+            for i in range(4):
+                assert store.lookup(f"/v{i}.mp4", 15) is not None
+
+            # Insert 5th -> v0 (oldest, lowest tick) gets evicted
+            store.put("/v4.mp4", 0, 30, _make_gop_data(256, seed=4))
+
+            assert store.lookup("/v0.mp4", 15) is None, "v0 should be evicted"
+            assert store.lookup("/v4.mp4", 15) is not None, "v4 should be present"
+
+            stats = store.get_stats()
+            assert stats['evictions'] == 1
+        finally:
+            store.cleanup()
+
+    def test_access_refreshes_lru(self, store_id):
+        """Accessing an entry prevents it from being evicted."""
+        store = SharedGopStore.create(capacity=4, store_id=store_id)
+        try:
+            for i in range(4):
+                store.put(f"/v{i}.mp4", 0, 30, _make_gop_data(256, seed=i))
+
+            # Touch v0 so it's no longer the oldest
+            store.lookup("/v0.mp4", 15)
+
+            # Insert 5th -> v1 (now the oldest) gets evicted, not v0
+            store.put("/v4.mp4", 0, 30, _make_gop_data(256, seed=4))
+
+            assert store.lookup("/v0.mp4", 15) is not None, "v0 was touched, should survive"
+            assert store.lookup("/v1.mp4", 15) is None, "v1 should be evicted"
+        finally:
+            store.cleanup()
+
+
+# ---------------------------------------------------------------------------
+# get_batch + orphan cleanup
+# ---------------------------------------------------------------------------
+
+class TestGetBatch:
+    """get_batch() reads shm blocks and cleans orphans."""
+
+    def test_get_batch_returns_correct_data(self, store):
+        data0 = _make_gop_data(512, seed=10)
+        data1 = _make_gop_data(768, seed=20)
+        ref0 = store.put("/v0.mp4", 0, 30, data0)
+        ref1 = store.put("/v1.mp4", 0, 30, data1)
+
+        arrays = store.get_batch([ref0, ref1])
+        assert len(arrays) == 2
+        np.testing.assert_array_equal(arrays[0], data0)
+        np.testing.assert_array_equal(arrays[1], data1)
+
+    def test_get_batch_cleans_orphans(self, store_id):
+        """After eviction + get_batch, orphaned shm blocks are unlinked."""
+        store = SharedGopStore.create(capacity=2, store_id=store_id)
+        try:
+            ref0 = store.put("/v0.mp4", 0, 30, _make_gop_data(256, seed=0))
+            store.put("/v1.mp4", 0, 30, _make_gop_data(256, seed=1))
+
+            # Evict v0 by inserting v2
+            ref2 = store.put("/v2.mp4", 0, 30, _make_gop_data(256, seed=2))
+
+            # v0's shm block still exists on disk (not unlinked yet)
+            orphan_path = f"/dev/shm/{ref0.shm_name}"
+            assert os.path.exists(orphan_path), "Orphan should still exist before get_batch"
+
+            # get_batch cleans up the orphan
+            store.get_batch([ref2])
+
+            assert not os.path.exists(orphan_path), "Orphan should be unlinked after get_batch"
+        finally:
+            store.cleanup()
+
+    def test_get_batch_empty_list(self, store):
+        """get_batch([]) should not crash."""
+        result = store.get_batch([])
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# Capacity-too-small fallback (evicted before read)
+# ---------------------------------------------------------------------------
+
+class TestCapacityTooSmall:
+    """read() returns zeros + RuntimeWarning when shm block was evicted."""
+
+    def test_read_evicted_returns_zeros_with_warning(self, store_id):
+        """When a GOP is evicted before main reads it, read() returns zeros."""
+        store = SharedGopStore.create(capacity=2, store_id=store_id)
+        try:
+            data0 = _make_gop_data(512, seed=0)
+            ref0 = store.put("/v0.mp4", 0, 30, data0)
+            store.put("/v1.mp4", 0, 30, _make_gop_data(512, seed=1))
+
+            # Evict v0 by inserting v2
+            store.put("/v2.mp4", 0, 30, _make_gop_data(512, seed=2))
+
+            # Manually unlink the orphaned shm block (simulates _unlink_orphans)
+            orphan_path = f"/dev/shm/{ref0.shm_name}"
+            if os.path.exists(orphan_path):
+                from multiprocessing import shared_memory
+                shm = shared_memory.SharedMemory(name=ref0.shm_name, create=False)
+                shm.close()
+                shm.unlink()
+
+            assert not os.path.exists(orphan_path), "Orphan must be gone before test"
+
+            # read() should return zeros and emit RuntimeWarning
+            with warnings.catch_warnings(record=True) as w:
+                warnings.simplefilter("always")
+                result = store.read(ref0)
+
+                assert len(w) == 1
+                assert issubclass(w[0].category, RuntimeWarning)
+                assert "Increase store capacity" in str(w[0].message)
+                assert f"current: {store.capacity}" in str(w[0].message)
+                assert ref0.shm_name in str(w[0].message)
+
+            # Returned array should be zeros with correct size
+            assert result.shape == (ref0.data_size,)
+            assert result.dtype == np.uint8
+            np.testing.assert_array_equal(result, np.zeros(ref0.data_size, dtype=np.uint8))
+        finally:
+            store.cleanup()
+
+    def test_get_batch_with_evicted_ref(self, store_id):
+        """get_batch() handles a mix of valid and evicted refs gracefully."""
+        store = SharedGopStore.create(capacity=2, store_id=store_id)
+        try:
+            data0 = _make_gop_data(256, seed=0)
+            data1 = _make_gop_data(256, seed=1)
+            ref0 = store.put("/v0.mp4", 0, 30, data0)
+            ref1 = store.put("/v1.mp4", 0, 30, data1)
+
+            # Evict v0
+            data2 = _make_gop_data(256, seed=2)
+            ref2 = store.put("/v2.mp4", 0, 30, data2)
+
+            # Unlink orphan
+            orphan_path = f"/dev/shm/{ref0.shm_name}"
+            if os.path.exists(orphan_path):
+                from multiprocessing import shared_memory
+                shm = shared_memory.SharedMemory(name=ref0.shm_name, create=False)
+                shm.close()
+                shm.unlink()
+
+            # get_batch with [evicted_ref, valid_ref]
+            with warnings.catch_warnings(record=True) as w:
+                warnings.simplefilter("always")
+                arrays = store.get_batch([ref0, ref2])
+
+                assert len(w) == 1
+                assert issubclass(w[0].category, RuntimeWarning)
+
+            assert len(arrays) == 2
+            # First is zeros (evicted)
+            np.testing.assert_array_equal(arrays[0], np.zeros(ref0.data_size, dtype=np.uint8))
+            # Second is valid data
+            np.testing.assert_array_equal(arrays[1], data2)
+        finally:
+            store.cleanup()
+
+
+# ---------------------------------------------------------------------------
+# attach errors
+# ---------------------------------------------------------------------------
+
+class TestAttachErrors:
+
+    def test_attach_nonexistent_raises(self):
+        """attach() raises FileNotFoundError with helpful message."""
+        with pytest.raises(FileNotFoundError, match="create\\(\\)"):
+            SharedGopStore.attach(capacity=4, store_id=8888)
+
+
+# ---------------------------------------------------------------------------
+# Multiple stores isolation
+# ---------------------------------------------------------------------------
+
+class TestStoreIsolation:
+    """Different store_ids do not interfere."""
+
+    def test_two_stores_independent(self):
+        sid_a = _BASE_STORE_ID + 900
+        sid_b = _BASE_STORE_ID + 901
+        store_a = SharedGopStore.create(capacity=4, store_id=sid_a)
+        store_b = SharedGopStore.create(capacity=4, store_id=sid_b)
+        try:
+            store_a.put("/v.mp4", 0, 30, _make_gop_data(256, seed=1))
+            store_b.put("/v.mp4", 0, 30, _make_gop_data(256, seed=2))
+
+            ref_a = store_a.lookup("/v.mp4", 15)
+            ref_b = store_b.lookup("/v.mp4", 15)
+
+            assert ref_a is not None
+            assert ref_b is not None
+            assert ref_a.shm_name != ref_b.shm_name
+
+            # Cleanup A should not affect B
+            store_a.cleanup()
+            assert store_b.lookup("/v.mp4", 15) is not None
+        finally:
+            store_b.cleanup()
+            # Ensure both are cleaned
+            for path in _shm_files_for_store(sid_a) + _shm_files_for_store(sid_b):
+                try:
+                    os.unlink(path)
+                except OSError:
+                    pass
+
+
+# ---------------------------------------------------------------------------
+# Cross-process test (spawn mode)
+# ---------------------------------------------------------------------------
+
+def _worker_fn(store_id, capacity, video_path, first_frame_id, gop_len, data_bytes, result_queue):
+    """Worker process: attach to store, put data, lookup, send result back."""
+    store = SharedGopStore.attach(capacity=capacity, store_id=store_id)
+    data = np.frombuffer(data_bytes, dtype=np.uint8)
+    ref = store.put(video_path, first_frame_id, gop_len, data)
+    hit = store.lookup(video_path, first_frame_id)
+    result_queue.put({
+        'ref': ref,
+        'hit': hit,
+    })
+    store.close()
+
+
+class TestCrossProcess:
+    """Verify SharedGopStore works across spawn'd processes."""
+
+    def test_worker_put_main_lookup(self):
+        sid = _BASE_STORE_ID + 950
+        capacity = 8
+        store = SharedGopStore.create(capacity=capacity, store_id=sid)
+        try:
+            data = _make_gop_data(2048, seed=99)
+            ctx = multiprocessing.get_context("spawn")
+            q = ctx.Queue()
+
+            p = ctx.Process(
+                target=_worker_fn,
+                args=(sid, capacity, "/cross/v.mp4", 0, 30, data.tobytes(), q),
+            )
+            p.start()
+            p.join(timeout=30)
+            assert p.exitcode == 0, f"Worker exited with code {p.exitcode}"
+
+            result = q.get(timeout=5)
+            worker_ref = result['ref']
+            worker_hit = result['hit']
+
+            # Worker's put and lookup should succeed
+            assert isinstance(worker_ref, GopRef)
+            assert worker_hit is not None
+            assert worker_hit.shm_name == worker_ref.shm_name
+
+            # Main process can see what worker put
+            main_hit = store.lookup("/cross/v.mp4", 15)
+            assert main_hit is not None
+            assert main_hit.shm_name == worker_ref.shm_name
+
+            # Main process can read the data
+            view = store.read(main_hit)
+            np.testing.assert_array_equal(view, data)
+        finally:
+            store.cleanup()
+
+
+# ---------------------------------------------------------------------------
+# Statistics
+# ---------------------------------------------------------------------------
+
+class TestStats:
+    """get_stats / reset_stats correctness."""
+
+    def test_stats_after_operations(self, store):
+        store.put("/v.mp4", 0, 30, _make_gop_data(256))
+
+        store.lookup("/v.mp4", 15)   # hit
+        store.lookup("/v.mp4", 15)   # hit
+        store.lookup("/other.mp4", 0)  # miss
+
+        stats = store.get_stats()
+        # put() does a double-check lookup internally, so hits includes that.
+        # External: 2 hits + 1 miss.  put's internal lookup was a miss (first put).
+        # Total hits: 2 (external), total misses: 1 (external) + 1 (put's internal) = 2
+        # But put also increments puts counter.
+        assert stats['puts'] == 1
+        assert stats['hits'] >= 2
+        assert stats['misses'] >= 1
+        assert 0.0 <= stats['hit_rate'] <= 1.0
+        assert stats['pool_usage'] == "1/8"
+
+    def test_reset_stats(self, store):
+        store.put("/v.mp4", 0, 30, _make_gop_data(256))
+        store.lookup("/v.mp4", 15)
+        store.reset_stats()
+
+        stats = store.get_stats()
+        assert stats['hits'] == 0
+        assert stats['misses'] == 0
+        assert stats['puts'] == 0
+        assert stats['evictions'] == 0
+        # pool_usage is from shared metadata, not reset
+        assert stats['pool_usage'] == "1/8"
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/packages/on_demand_video_decoder/tests/test_shared_gop_store.py
+++ b/packages/on_demand_video_decoder/tests/test_shared_gop_store.py
@@ -543,5 +543,30 @@ class TestStats:
         assert stats['pool_usage'] == "1/8"
 
 
+# ---------------------------------------------------------------------------
+# Factory enforcement (direct construction must be blocked)
+# ---------------------------------------------------------------------------
+
+
+class TestFactoryEnforcement:
+    """Direct __init__ calls must raise; only create()/attach() are valid."""
+
+    def test_direct_construction_raises(self, store_id):
+        """SharedGopStore(...) without the private key must raise RuntimeError."""
+        with pytest.raises(RuntimeError, match="cannot be instantiated directly"):
+            SharedGopStore(capacity=4, store_id=store_id, _create=True)
+
+    def test_direct_construction_error_mentions_factories(self, store_id):
+        """Error message must point users to create() and attach()."""
+        with pytest.raises(RuntimeError, match=r"create\(\).*attach\(\)"):
+            SharedGopStore(capacity=4, store_id=store_id, _create=True)
+
+    def test_direct_construction_does_not_allocate_shm(self, store_id):
+        """A blocked construction must reject before touching shm."""
+        with pytest.raises(RuntimeError):
+            SharedGopStore(capacity=4, store_id=store_id, _create=True)
+        assert _shm_files_for_store(store_id) == [], "shm leaked despite blocked construction"
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Description

### SharedGopStore: Cross-process shared GOP store with zero-copy IPC

#### Summary

Add `SharedGopStore` to `accvlab.on_demand_video_decoder` — a general-purpose cross-process GOP store backed by POSIX shared memory, with a metadata/data split-channel architecture for efficient inter-process communication. It can be used in `separation decoder` and `demuxer-free deocder`.

**Problem:** In multi-process video pipelines (training, inference, preprocessing), GOP data is frequently needed across process boundaries. Traditional approaches either (1) let each process independently demux the same GOP, wasting I/O and CPU, or (2) serialize full GOP packets through IPC queues, incurring copy overhead that scales with data size.

**Solution:** `SharedGopStore` separates GOP transport into two channels:

- **Data channel (shared memory):** GOP packets are written once to POSIX SharedMemory (`/dev/shm`) by any process. Consumers read the data as zero-copy numpy views — no serialization, no memcpy.
- **Metadata channel (IPC):** Lightweight `GopRef` references (~60 bytes) are passed through standard IPC mechanisms (queues, pipes, etc.). `GopRef` is a picklable `NamedTuple` containing only the shm block name, data size, and frame range — orders of magnitude smaller than the actual GOP data (4-40 KB).

This architecture decouples data placement from data referencing, enabling GOP reuse across processes without redundant demuxing or serialization overhead. Cross-process safety is ensured by `flock`-based locking compatible with `spawn`'d processes, and LRU eviction keeps memory usage bounded.

We validate the design by integrating `SharedGopStore` into the StreamPETR demuxer-free video training pipeline, where it eliminates cross-worker GOP redundancy in multi-camera setups.

#### Performance (NuScenes-mini x8, demuxer-free decoder)

Data loading time (`data_time`, median) — isolates the data pipeline contribution:

bs = 8
| GPUs | Image   | OpenCV  | Demuxer-Free | **+ SharedGopStore** | vs Image | vs OpenCV |
|------|---------|---------|--------------|--------------------- |----------|-----------|
| 1    | 55 ms   | 60 ms   | 6 ms         | **6 ms**             | 9.2x     | 10.0x     |
| 2    | 56 ms   | 62 ms   | 8 ms         | **6 ms**             | 9.3x     | 10.3x     |
| 4    | 61 ms   | 64 ms   | 14 ms        | **10 ms**            | 6.1x     | 6.4x      |
| 8    | 69 ms   | 91 ms   | 22 ms        | **9 ms**             | 7.7x     | 10.1x     |

SharedGopStore's `data_time` stays nearly flat (6-10 ms) regardless of GPU count, while Image grows from 55→69 ms and OpenCV from 60→91 ms. The cross-worker shared cache eliminates redundant demuxing that worsens with more workers.

End-to-end iteration time — GPU scaling (fixed per-GPU bs=8):

| GPUs | Image (s) | OpenCV (s) | Demuxer-Free (s) | **+ SharedGopStore (s)** | vs Image | vs OpenCV |
|------|-----------|------------|-------------------|--------------------------|----------|-----------|
| 1    | 0.847     | 0.971      | 0.770             | **0.760**                | 1.11x    | 1.28x     |
| 2    | 0.772     | 0.914      | 0.754             | **0.725**                | 1.07x    | 1.26x     |
| 4    | 0.823     | 1.056      | 0.789             | **0.768**                | 1.07x    | 1.38x     |
| 8    | 0.875     | 1.452      | 0.859             | **0.804**                | 1.09x    | 1.81x     |

End-to-end iteration time — batch size scaling (fixed 8 GPUs):

| BS | Image (s) | OpenCV (s) | Demuxer-Free (s) | **+ SharedGopStore (s)** | vs Image | vs OpenCV |
|----|-----------|------------|-------------------|--------------------------|----------|-----------|
| 1  | 0.263     | 0.350      | 0.247             | **0.235**                | 1.12x    | 1.49x     |
| 2  | 0.356     | 0.515      | 0.316             | **0.292**                | 1.22x    | 1.76x     |
| 4  | 0.516     | 0.964      | 0.476             | **0.459**                | 1.12x    | 2.10x     |
| 8  | 0.875     | 1.452      | 0.849             | **0.804**                | 1.09x    | 1.81x     |
| 16 | 1.671     | 3.536      | 1.676             | **1.462**                | 1.14x    | 2.42x     |

## Type of Change

Please select (at least one):
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation / examples / tutorials / demos
- [ ] Supporting functionality change (fix or feature in documentation generation, helper scripts, ...)
- [ ] Refactoring / internal change
- [ ] Other (please describe):

## Testing

Checklist for testing:
- [x] Tests added or updated if/as needed
- [x] Repository test runner executed: `scripts/run_tests.sh`

Optionally, add a brief description.

## Documentation, Examples, Tutorials, Demos

Checklist for documentation:
- [x] User-facing documentation updated if/as needed (including API docs)
- [ ] Examples / tutorials / demos updated or added (if relevant)
- [ ] Limitations and constraints documented (if relevant)
- [ ] Performance documented (if relevant)
- [ ] Documentation building successful & checks outlined in the [Documentation Checks](/NVIDIA/ACCV-Lab/blob/main/docs/guides/CONTRIBUTION_GUIDE.md#documentation-checks) section of the [Contribution Guide](/NVIDIA/ACCV-Lab/blob/main/docs/guides/CONTRIBUTION_GUIDE.md) are performed

Optionally, add a brief description.

## Code Quality

Checklist for dependencies:
  - [ ] Dependencies updated in the relevant `pyproject.toml` if/as needed
  - [x] Code formatted according to the [Code Formatting Guide](/NVIDIA/ACCV-Lab/blob/main/docs/guides/FORMATTING_GUIDE.md)

Optionally, add a brief description.

## Related Issues / Context

If applicable, link related issues, discussions etc.

---

## DCO / Sign-Off

Please refer to the section on [Signing Your Work & Developer Certificate of Origin (DCO)](/NVIDIA/ACCV-Lab/blob/main/docs/guides/CONTRIBUTION_GUIDE.md#signing-your-work--developer-certificate-of-origin-dco)
in the Contribution Guide before submitting your contribution.

## References

For additional details, please refer to the [Contribution Guide](/NVIDIA/ACCV-Lab/blob/main/docs/guides/CONTRIBUTION_GUIDE.md).
The following guides are available (referenced in the Contribution Guide for further details):
- [`docs/guides/CONTRIBUTION_GUIDE.md`](/NVIDIA/ACCV-Lab/blob/main/docs/guides/CONTRIBUTION_GUIDE.md)
- [`docs/guides/DEVELOPMENT_GUIDE.md`](/NVIDIA/ACCV-Lab/blob/main/docs/guides/DEVELOPMENT_GUIDE.md)
- [`docs/guides/DOCUMENTATION_SETUP_GUIDE.md`](/NVIDIA/ACCV-Lab/blob/main/docs/guides/DOCUMENTATION_SETUP_GUIDE.md)
- [`docs/guides/FORMATTING_GUIDE.md`](/NVIDIA/ACCV-Lab/blob/main/docs/guides/FORMATTING_GUIDE.md)

Please also refer to the [summary checklist in the Contribution Guide](/NVIDIA/ACCV-Lab/blob/main/docs/guides/CONTRIBUTION_GUIDE.md#summary-checklist),
which is a guideline for what to consider when submitting your contribution and covers the same topics as the checklists above.
