### PR TITLE
Fixed Sphinx warnings (NamedTuple attributes processing & spelling)

### DIFF
--- a/docs/_ext/namedtuple_attributes.py
+++ b/docs/_ext/namedtuple_attributes.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import importlib
+import inspect
+import re
+from typing import Any
+
+from sphinx.application import Sphinx
+from sphinx.ext.napoleon.docstring import GoogleDocstring, NumpyDocstring
+
+ATTRIBUTE_DIRECTIVE_RE = re.compile(
+    r"^\s*\.\.\s+attribute::\s+([A-Za-z_]\w*)\s*$",
+    re.MULTILINE,
+)
+IVAR_RE = re.compile(r"^\s*:ivar\s+([A-Za-z_]\w*):", re.MULTILINE)
+
+# Cache per class and Napoleon setting combination because those settings change
+# how "Attributes:" sections are converted into Sphinx attribute directives.
+_DOCUMENTED_ATTRIBUTE_CACHE: dict[tuple[type[Any], bool, bool, bool], set[str]] = {}
+
+
+def _extract_documented_attributes(docstring: str) -> set[str]:
+    return set(ATTRIBUTE_DIRECTIVE_RE.findall(docstring)) | set(IVAR_RE.findall(docstring))
+
+
+def _resolve_current_autodoc_class(app: Sphinx) -> type[Any] | None:
+    env = getattr(app, "env", None)
+    if env is None:
+        return None
+
+    module_name = env.temp_data.get("autodoc:module")
+    class_path = env.temp_data.get("autodoc:class")
+    if not module_name or not class_path:
+        return None
+
+    try:
+        current_obj: Any = importlib.import_module(module_name)
+        for part in class_path.split("."):
+            current_obj = getattr(current_obj, part)
+    except Exception:
+        return None
+
+    return current_obj if isinstance(current_obj, type) else None
+
+
+def _documented_class_attributes(app: Sphinx, cls: type[Any]) -> set[str]:
+    cache_key = (
+        cls,
+        bool(app.config.napoleon_google_docstring),
+        bool(app.config.napoleon_numpy_docstring),
+        bool(app.config.napoleon_use_ivar),
+    )
+    if cache_key in _DOCUMENTED_ATTRIBUTE_CACHE:
+        return _DOCUMENTED_ATTRIBUTE_CACHE[cache_key]
+
+    doc = inspect.getdoc(cls) or ""
+    documented = _extract_documented_attributes(doc)
+
+    # Re-run the class docstring through Napoleon so Google/NumPy style
+    # "Attributes:" sections can be detected before skipping NamedTuple fields.
+    parser_args = {
+        "config": app.config,
+        "app": app,
+        "what": "class",
+        "name": cls.__qualname__,
+        "obj": cls,
+    }
+    if app.config.napoleon_google_docstring:
+        documented.update(_extract_documented_attributes(str(GoogleDocstring(doc, **parser_args))))
+    if app.config.napoleon_numpy_docstring:
+        documented.update(_extract_documented_attributes(str(NumpyDocstring(doc, **parser_args))))
+
+    _DOCUMENTED_ATTRIBUTE_CACHE[cache_key] = documented
+    return documented
+
+
+def skip_namedtuple_field_if_docstring_covers_it(
+    app: Sphinx,
+    what: str,
+    name: str,
+    obj: Any,
+    skip: bool,
+    options: dict[str, bool],
+) -> bool | None:
+    del obj, skip, options
+
+    # autodoc calls this hook for every member. Returning None lets Sphinx and
+    # other extensions keep their default decision for anything outside classes.
+    if what != "class":
+        return None
+
+    current_class = _resolve_current_autodoc_class(app)
+    if current_class is None:
+        return None
+
+    # NamedTuple classes expose fields through _fields. We only want to hide
+    # those field descriptors, not ordinary class attributes or methods.
+    fields = getattr(current_class, "_fields", None)
+    if not (issubclass(current_class, tuple) and isinstance(fields, tuple)):
+        return None
+
+    if name not in fields:
+        return None
+
+    documented_attributes = _documented_class_attributes(app, current_class)
+    if name in documented_attributes:
+        return True
+
+    return None
+
+
+def setup(app: Sphinx):
+    # Register with Sphinx autodoc's member-skip event so the extension can
+    # suppress duplicate NamedTuple field docs after autodoc has found them.
+    app.connect(
+        "autodoc-skip-member",
+        skip_namedtuple_field_if_docstring_covers_it,
+        # Higher priority than Sphinx's default of 500 so this runs later and
+        # only applies the NamedTuple-specific skip after other listeners.
+        priority=2000,
+    )
+    return {
+        "version": "0.1",
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -85,6 +85,7 @@ extensions = [
     'note_literalinclude',  # Local extension: note-literalinclude directive
     'module_docstring',  # Local extension: module-docstring directive
     'markdown_note_admonitions',  # Convert Markdown blockquotes to Sphinx admonitions
+    'namedtuple_attributes',  # Prefer docstring attribute docs over NamedTuple defaults
 ]
 
 # Optionally enable spelling if available; warn if not, including the original error

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -48,6 +48,7 @@ demuxer
 demuxers
 demuxing
 demuxes
+demuxed
 sharding
 gop
 GOP
@@ -199,3 +200,11 @@ walkthrough
 Walkthrough
 uv
 Ryzen
+Unlink
+unlink
+Unlinked
+unlinked
+Unlinking
+unlinking
+atomicity
+picklable


### PR DESCRIPTION
- Fixed warnings when documenting attributes on `NamedTuple`-derived classes
  - Added a Sphinx autodoc extension to skip `NamedTuple` field members when they are already documented in the class docstring
  - Extension detects attribute docs from explicit attribute directives, ivar fields, and napoleon-parsed google/numpy style attributes sections

- Updated spelling wordlist

## Description

Please provide a clear and concise description of your contribution:
- What does this change do?
- What problem does it solve and why is it needed?
- Which namespace packages or components are affected?

## Type of Change

Please select (at least one):
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation / examples / tutorials / demos
- [x] Supporting functionality change (fix or feature in documentation generation, helper scripts, ...)
- [ ] Refactoring / internal change
- [ ] Other (please describe):

## Testing

Checklist for testing:
- [ ] Tests added or updated if/as needed
- [ ] Repository test runner executed: `scripts/run_tests.sh`

Optionally, add a brief description.

## Documentation, Examples, Tutorials, Demos

Checklist for documentation:
- [ ] User-facing documentation updated if/as needed (including API docs)
- [ ] Examples / tutorials / demos updated or added (if relevant)
- [ ] Limitations and constraints documented (if relevant)
- [ ] Performance documented (if relevant)
- [x] Documentation building successful & checks outlined in the [Documentation Checks](/NVIDIA/ACCV-Lab/blob/main/docs/guides/CONTRIBUTION_GUIDE.md#documentation-checks) section of the [Contribution Guide](/NVIDIA/ACCV-Lab/blob/main/docs/guides/CONTRIBUTION_GUIDE.md) are performed

Optionally, add a brief description.

## Code Quality

Checklist for dependencies:
  - [ ] Dependencies updated in the relevant `pyproject.toml` if/as needed
  - [x] Code formatted according to the [Code Formatting Guide](/NVIDIA/ACCV-Lab/blob/main/docs/guides/FORMATTING_GUIDE.md)

Optionally, add a brief description.

## Related Issues / Context

If applicable, link related issues, discussions etc.

---

## DCO / Sign-Off

Please refer to the section on [Signing Your Work & Developer Certificate of Origin (DCO)](/NVIDIA/ACCV-Lab/blob/main/docs/guides/CONTRIBUTION_GUIDE.md#signing-your-work--developer-certificate-of-origin-dco)
in the Contribution Guide before submitting your contribution.

## References

For additional details, please refer to the [Contribution Guide](/NVIDIA/ACCV-Lab/blob/main/docs/guides/CONTRIBUTION_GUIDE.md).
The following guides are available (referenced in the Contribution Guide for further details):
- [`docs/guides/CONTRIBUTION_GUIDE.md`](/NVIDIA/ACCV-Lab/blob/main/docs/guides/CONTRIBUTION_GUIDE.md)
- [`docs/guides/DEVELOPMENT_GUIDE.md`](/NVIDIA/ACCV-Lab/blob/main/docs/guides/DEVELOPMENT_GUIDE.md)
- [`docs/guides/DOCUMENTATION_SETUP_GUIDE.md`](/NVIDIA/ACCV-Lab/blob/main/docs/guides/DOCUMENTATION_SETUP_GUIDE.md)
- [`docs/guides/FORMATTING_GUIDE.md`](/NVIDIA/ACCV-Lab/blob/main/docs/guides/FORMATTING_GUIDE.md)

Please also refer to the [summary checklist in the Contribution Guide](/NVIDIA/ACCV-Lab/blob/main/docs/guides/CONTRIBUTION_GUIDE.md#summary-checklist),
which is a guideline for what to consider when submitting your contribution and covers the same topics as the checklists above.
