### PR TITLE
Feat/bytes video decode

### DIFF
--- a/packages/on_demand_video_decoder/accvlab/on_demand_video_decoder/_internal/shared_gop_store.py
+++ b/packages/on_demand_video_decoder/accvlab/on_demand_video_decoder/_internal/shared_gop_store.py
@@ -48,7 +48,7 @@ import glob as glob_mod
 import hashlib
 import os
 from multiprocessing import shared_memory
-from typing import List, Optional
+from typing import Any, List, Optional
 
 import numpy as np
 
@@ -93,6 +93,31 @@ def _hash_video_path(video_path: str) -> np.uint64:
     """
     digest = hashlib.md5(video_path.encode()).digest()[:8]
     return np.uint64(int.from_bytes(digest, 'little'))
+
+
+def _as_byte_view(data: Any) -> memoryview:
+    """Return a C-contiguous uint8 memoryview over bytes-like GOP data."""
+    if isinstance(data, np.ndarray):
+        if not data.flags.c_contiguous:
+            data = np.ascontiguousarray(data)
+        view = memoryview(data)
+    else:
+        try:
+            view = memoryview(data)
+        except TypeError as exc:
+            raise TypeError("data must be a bytes-like object or numpy.ndarray") from exc
+        if not view.c_contiguous:
+            view = memoryview(view.tobytes())
+
+    if view.nbytes == 0:
+        raise ValueError("data must not be empty")
+
+    if view.ndim != 1 or view.itemsize != 1 or view.format not in ('B', 'b', 'c'):
+        try:
+            view = view.cast('B')
+        except TypeError as exc:
+            raise TypeError("data must expose a C-contiguous byte buffer") from exc
+    return view
 
 
 class SharedGopStore:
@@ -254,8 +279,12 @@ class SharedGopStore:
         self._misses += 1
         return None
 
-    def put(self, video_path: str, first_frame_id: int, gop_len: int, data: np.ndarray) -> GopRef:
+    def put(self, video_path: str, first_frame_id: int, gop_len: int, data: Any) -> GopRef:
         """Store GOP packet data and return a :class:`GopRef`.
+
+        ``data`` may be a ``uint8`` numpy array or any C-contiguous
+        bytes-like object, including ``bytes``, ``bytearray``, and
+        ``memoryview``.
 
         Holds ``flock`` during eviction + insertion to guarantee atomicity.
         Performs a double-check after acquiring the lock (another worker
@@ -282,17 +311,18 @@ class SharedGopStore:
                         gop_len=int(e['gop_len']),
                     )
 
+            data_view = _as_byte_view(data)
             slot_idx = self._find_free_or_evict()
 
             # Content-addressed naming -- same GOP always gets the same name.
             shm_name = f"{_SHM_PREFIX}_{self.store_id}_{vp_hash}_{first_frame_id}"
-            data_size = int(data.nbytes)
+            data_size = int(data_view.nbytes)
 
             # Clean up if same GOP was previously cached then evicted
             _cleanup_stale_shm(shm_name)
 
             shm = shared_memory.SharedMemory(name=shm_name, create=True, size=data_size)
-            shm.buf[:data_size] = data.tobytes()
+            shm.buf[:data_size] = data_view
             shm.close()  # close handle; shm persists until unlink
 
             # Write metadata entry

--- a/packages/on_demand_video_decoder/ext_impl/src/PyNvOnDemandDecoder/inc/PyNvGopDecoder.hpp
+++ b/packages/on_demand_video_decoder/ext_impl/src/PyNvOnDemandDecoder/inc/PyNvGopDecoder.hpp
@@ -105,6 +105,10 @@ class PyNvGopDecoder {
                                    const std::vector<int> frame_ids,
                                    const FastStreamInfo* fastStreamInfos = nullptr);
 
+    SerializedPacketBundle get_gop_from_bytes(std::shared_ptr<const std::vector<uint8_t>> data,
+                                              const std::vector<int> frame_ids,
+                                              const std::string& source_name = "memory://video");
+
     /**
      * Extract GOP data for multiple videos and return them as separate bundles
      * 

--- a/packages/on_demand_video_decoder/ext_impl/src/PyNvOnDemandDecoder/inc/PyNvGopDecoder.hpp
+++ b/packages/on_demand_video_decoder/ext_impl/src/PyNvOnDemandDecoder/inc/PyNvGopDecoder.hpp
@@ -106,8 +106,7 @@ class PyNvGopDecoder {
                                    const FastStreamInfo* fastStreamInfos = nullptr);
 
     SerializedPacketBundle get_gop_from_bytes(std::shared_ptr<const std::vector<uint8_t>> data,
-                                              const std::vector<int> frame_ids,
-                                              const std::string& source_name = "memory://video");
+                                              const std::vector<int> frame_ids);
 
     /**
      * Extract GOP data for multiple videos and return them as separate bundles

--- a/packages/on_demand_video_decoder/ext_impl/src/PyNvOnDemandDecoder/inc/PyNvGopDemuxer.hpp
+++ b/packages/on_demand_video_decoder/ext_impl/src/PyNvOnDemandDecoder/inc/PyNvGopDemuxer.hpp
@@ -40,7 +40,7 @@ class PyNvGopDemuxer {
    public:
     explicit PyNvGopDemuxer(const std::string&);
     explicit PyNvGopDemuxer(const std::string& filePath, const FastStreamInfo* fastStreamInfo);
-    explicit PyNvGopDemuxer(const std::string& sourceName,
+    explicit PyNvGopDemuxer(const std::string& filePath,
                             std::shared_ptr<const std::vector<uint8_t>> memoryData);
 
     uint32_t GetHeight() { return demuxer->GetHeight(); }

--- a/packages/on_demand_video_decoder/ext_impl/src/PyNvOnDemandDecoder/inc/PyNvGopDemuxer.hpp
+++ b/packages/on_demand_video_decoder/ext_impl/src/PyNvOnDemandDecoder/inc/PyNvGopDemuxer.hpp
@@ -18,11 +18,13 @@
 
 #include "FFmpegDemuxer.h"
 #include <map>
+#include <memory>
 #include <pybind11/cast.h>
 #include <pybind11/embed.h>
 #include <pybind11/numpy.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
+#include <vector>
 extern "C" {
 #include <libavutil/frame.h>
 }
@@ -38,6 +40,8 @@ class PyNvGopDemuxer {
    public:
     explicit PyNvGopDemuxer(const std::string&);
     explicit PyNvGopDemuxer(const std::string& filePath, const FastStreamInfo* fastStreamInfo);
+    explicit PyNvGopDemuxer(const std::string& sourceName,
+                            std::shared_ptr<const std::vector<uint8_t>> memoryData);
 
     uint32_t GetHeight() { return demuxer->GetHeight(); }
 

--- a/packages/on_demand_video_decoder/ext_impl/src/PyNvOnDemandDecoder/src/PyNvGopDecoder_constructors.cpp
+++ b/packages/on_demand_video_decoder/ext_impl/src/PyNvOnDemandDecoder/src/PyNvGopDecoder_constructors.cpp
@@ -34,6 +34,28 @@
 
 namespace fs = std::filesystem;
 
+namespace {
+std::shared_ptr<std::vector<uint8_t>> CopyByteBuffer(const py::buffer& buffer) {
+    py::buffer_info info = buffer.request();
+    if (info.itemsize != 1) {
+        throw std::invalid_argument("video_bytes must expose a byte-sized buffer");
+    }
+    if (info.ndim > 1) {
+        throw std::invalid_argument("video_bytes must be a contiguous 1D bytes-like object");
+    }
+    if (info.ndim == 1 && !info.strides.empty() && info.strides[0] != 1) {
+        throw std::invalid_argument("video_bytes must be contiguous");
+    }
+
+    const auto* src = static_cast<const uint8_t*>(info.ptr);
+    auto data = std::make_shared<std::vector<uint8_t>>(src, src + info.size * info.itemsize);
+    if (data->empty()) {
+        throw std::invalid_argument("video_bytes must not be empty");
+    }
+    return data;
+}
+}  // namespace
+
 std::vector<FastStreamInfo> GetFastInitInfo(const std::vector<std::string>& filepaths) {
     std::vector<FastStreamInfo> fast_stream_infos;
     fast_stream_infos.reserve(filepaths.size());
@@ -488,6 +510,34 @@ void Init_PyNvGopDecoder(py::module& m) {
                 >>> print(f"Decoded {len(rgb_frames)} RGB frames")
             )pbdoc")
         .def(
+            "DecodeN12ToRGBFromBytes",
+            [](std::shared_ptr<PyNvGopDecoder>& dec, const py::buffer& video_bytes,
+               const std::vector<int> frame_ids, bool as_bgr) {
+                try {
+                    auto data = CopyByteBuffer(video_bytes);
+                    SerializedPacketBundle serialized_data;
+                    std::vector<RGBFrame> result;
+                    std::vector<std::string> source_names(frame_ids.size(), "memory://video");
+
+                    {
+                        py::gil_scoped_release release;
+                        serialized_data = dec->get_gop_from_bytes(data, frame_ids, "memory://video");
+                        dec->decode_from_gop(serialized_data.data.get(), serialized_data.size,
+                                             source_names, frame_ids, true, as_bgr, nullptr, &result);
+                    }
+                    return result;
+                } catch (const std::exception& e) {
+                    throw std::runtime_error(e.what());
+                }
+            },
+            py::arg("video_bytes"), py::arg("frame_ids"), py::arg("as_bgr") = false,
+            R"pbdoc(
+            Decodes frames from a complete MP4 byte buffer into RGB/BGR data.
+
+            This method is a memory-input variant of DecodeN12ToRGB. The input must be
+            a complete seekable container byte buffer, not a live stream.
+            )pbdoc")
+        .def(
             "GetGOP",
             [](std::shared_ptr<PyNvGopDecoder>& dec, const std::vector<std::string>& filepaths,
                const std::vector<int> frame_ids, std::vector<FastStreamInfo> fastStreamInfos) {
@@ -555,6 +605,35 @@ void Init_PyNvGopDecoder(py::module& m) {
                 >>> decoder = PyNvGopDecoder(maxfiles=10)
                 >>> gop_data, first_ids, gop_lens = decoder.GetGOP(['video.mp4', 'video2.mp4'], [0, 10])
                 >>> print(f"Extracted GOP data for {len(first_ids)} GOPs")
+            )pbdoc")
+        .def(
+            "GetGOPFromBytes",
+            [](std::shared_ptr<PyNvGopDecoder>& dec, const py::buffer& video_bytes,
+               const std::vector<int> frame_ids) {
+                try {
+                    auto data = CopyByteBuffer(video_bytes);
+                    SerializedPacketBundle serialized_data;
+                    {
+                        py::gil_scoped_release release;
+                        serialized_data = dec->get_gop_from_bytes(data, frame_ids, "memory://video");
+                    }
+
+                    auto capsule = py::capsule(serialized_data.data.release(),
+                                               [](void* ptr) { delete[] static_cast<uint8_t*>(ptr); });
+                    py::array_t<uint8_t> numpy_data(serialized_data.size,
+                                                    static_cast<uint8_t*>(capsule.get_pointer()), capsule);
+                    return py::make_tuple(numpy_data, serialized_data.first_frame_ids,
+                                          serialized_data.gop_lens);
+                } catch (const std::exception& e) {
+                    throw std::runtime_error(e.what());
+                }
+            },
+            py::arg("video_bytes"), py::arg("frame_ids"),
+            R"pbdoc(
+            Extracts GOP packet data from a complete MP4 byte buffer.
+
+            This is the memory-input variant of GetGOP and is intended for sources
+            such as FFRecord records or mmap slices that contain complete MP4 bytes.
             )pbdoc")
         .def(
             "GetGOPList",

--- a/packages/on_demand_video_decoder/ext_impl/src/PyNvOnDemandDecoder/src/PyNvGopDecoder_constructors.cpp
+++ b/packages/on_demand_video_decoder/ext_impl/src/PyNvOnDemandDecoder/src/PyNvGopDecoder_constructors.cpp
@@ -35,23 +35,29 @@
 namespace fs = std::filesystem;
 
 namespace {
-std::shared_ptr<std::vector<uint8_t>> CopyByteBuffer(const py::buffer& buffer) {
+py::buffer_info RequestByteBuffer(const py::buffer& buffer, const std::string& arg_name) {
     py::buffer_info info = buffer.request();
     if (info.itemsize != 1) {
-        throw std::invalid_argument("video_bytes must expose a byte-sized buffer");
+        throw std::invalid_argument(arg_name + " must expose a byte-sized buffer");
     }
     if (info.ndim > 1) {
-        throw std::invalid_argument("video_bytes must be a contiguous 1D bytes-like object");
+        throw std::invalid_argument(arg_name + " must be a contiguous 1D bytes-like object");
     }
     if (info.ndim == 1 && !info.strides.empty() && info.strides[0] != 1) {
-        throw std::invalid_argument("video_bytes must be contiguous");
+        throw std::invalid_argument(arg_name + " must be contiguous");
     }
 
+    const size_t data_size = static_cast<size_t>(info.size) * static_cast<size_t>(info.itemsize);
+    if (data_size == 0) {
+        throw std::invalid_argument(arg_name + " must not be empty");
+    }
+    return info;
+}
+
+std::shared_ptr<std::vector<uint8_t>> CopyByteBuffer(const py::buffer& buffer) {
+    py::buffer_info info = RequestByteBuffer(buffer, "video_bytes");
     const auto* src = static_cast<const uint8_t*>(info.ptr);
     auto data = std::make_shared<std::vector<uint8_t>>(src, src + info.size * info.itemsize);
-    if (data->empty()) {
-        throw std::invalid_argument("video_bytes must not be empty");
-    }
     return data;
 }
 }  // namespace
@@ -517,13 +523,13 @@ void Init_PyNvGopDecoder(py::module& m) {
                     auto data = CopyByteBuffer(video_bytes);
                     SerializedPacketBundle serialized_data;
                     std::vector<RGBFrame> result;
-                    std::vector<std::string> source_names(frame_ids.size(), "memory://video");
+                    std::vector<std::string> filepaths(frame_ids.size(), "memory://video");
 
                     {
                         py::gil_scoped_release release;
-                        serialized_data = dec->get_gop_from_bytes(data, frame_ids, "memory://video");
+                        serialized_data = dec->get_gop_from_bytes(data, frame_ids);
                         dec->decode_from_gop(serialized_data.data.get(), serialized_data.size,
-                                             source_names, frame_ids, true, as_bgr, nullptr, &result);
+                                             filepaths, frame_ids, true, as_bgr, nullptr, &result);
                     }
                     return result;
                 } catch (const std::exception& e) {
@@ -615,7 +621,7 @@ void Init_PyNvGopDecoder(py::module& m) {
                     SerializedPacketBundle serialized_data;
                     {
                         py::gil_scoped_release release;
-                        serialized_data = dec->get_gop_from_bytes(data, frame_ids, "memory://video");
+                        serialized_data = dec->get_gop_from_bytes(data, frame_ids);
                     }
 
                     auto capsule = py::capsule(serialized_data.data.release(),

--- a/packages/on_demand_video_decoder/ext_impl/src/PyNvOnDemandDecoder/src/PyNvGopDecoder_separate_decoder.cpp
+++ b/packages/on_demand_video_decoder/ext_impl/src/PyNvOnDemandDecoder/src/PyNvGopDecoder_separate_decoder.cpp
@@ -153,8 +153,7 @@ SerializedPacketBundle PyNvGopDecoder::get_gop(const std::vector<std::string>& f
 }
 
 SerializedPacketBundle PyNvGopDecoder::get_gop_from_bytes(
-    std::shared_ptr<const std::vector<uint8_t>> data, const std::vector<int> frame_ids,
-    const std::string& source_name) {
+    std::shared_ptr<const std::vector<uint8_t>> data, const std::vector<int> frame_ids) {
     nvtxRangePushA("GetGOPFromBytes");
 
     if (!data || data->empty()) {
@@ -188,12 +187,11 @@ SerializedPacketBundle PyNvGopDecoder::get_gop_from_bytes(
 
     nvtxRangePushA("Initialize memory demuxers");
     for (size_t i = 0; i < total_frames; ++i) {
-        std::string per_frame_source = source_name + "#" + std::to_string(i);
-        demuxers[i].reset(new PyNvGopDemuxer(per_frame_source, data));
+        demuxers[i].reset(new PyNvGopDemuxer("memory://video", data));
         if (!demuxers[i]->IsValid()) {
             nvtxRangePop();  // Initialize memory demuxers
             nvtxRangePop();  // GetGOPFromBytes
-            throw std::runtime_error("[ERROR] create memory demuxer failed: " + per_frame_source);
+            throw std::runtime_error("[ERROR] create memory demuxer failed");
         }
     }
     nvtxRangePop();  // Initialize memory demuxers

--- a/packages/on_demand_video_decoder/ext_impl/src/PyNvOnDemandDecoder/src/PyNvGopDecoder_separate_decoder.cpp
+++ b/packages/on_demand_video_decoder/ext_impl/src/PyNvOnDemandDecoder/src/PyNvGopDecoder_separate_decoder.cpp
@@ -152,6 +152,114 @@ SerializedPacketBundle PyNvGopDecoder::get_gop(const std::vector<std::string>& f
     return result;
 }
 
+SerializedPacketBundle PyNvGopDecoder::get_gop_from_bytes(
+    std::shared_ptr<const std::vector<uint8_t>> data, const std::vector<int> frame_ids,
+    const std::string& source_name) {
+    nvtxRangePushA("GetGOPFromBytes");
+
+    if (!data || data->empty()) {
+        throw std::invalid_argument("[ERROR] video byte buffer is empty");
+    }
+    if (frame_ids.empty()) {
+        throw std::invalid_argument("[ERROR] frame_ids must not be empty");
+    }
+    if (frame_ids.size() > max_num_files) {
+        throw std::invalid_argument("[ERROR] frame_ids size is greater than max_num_files");
+    }
+
+    const size_t total_frames = frame_ids.size();
+
+    std::vector<std::unique_ptr<PyNvGopDemuxer>> demuxers;
+    std::vector<std::unique_ptr<ConcurrentQueue<std::tuple<uint8_t*, int, int>>>> vpacket_queue;
+    std::vector<std::vector<std::unique_ptr<uint8_t[]>>> vpacket_array;
+    std::vector<std::vector<int>> all_gop_lens(total_frames);
+    std::vector<std::vector<int>> all_first_frame_ids(total_frames);
+
+    demuxers.resize(total_frames);
+    vpacket_queue.reserve(total_frames);
+    vpacket_array.reserve(total_frames);
+    for (size_t i = 0; i < total_frames; ++i) {
+        vpacket_queue.emplace_back(std::make_unique<ConcurrentQueue<std::tuple<uint8_t*, int, int>>>());
+        vpacket_queue[i]->setSize(MAX_SIZE);
+        vpacket_array.emplace_back();
+    }
+
+    ensureDemuxRunnersInitialized();
+
+    nvtxRangePushA("Initialize memory demuxers");
+    for (size_t i = 0; i < total_frames; ++i) {
+        std::string per_frame_source = source_name + "#" + std::to_string(i);
+        demuxers[i].reset(new PyNvGopDemuxer(per_frame_source, data));
+        if (!demuxers[i]->IsValid()) {
+            nvtxRangePop();  // Initialize memory demuxers
+            nvtxRangePop();  // GetGOPFromBytes
+            throw std::runtime_error("[ERROR] create memory demuxer failed: " + per_frame_source);
+        }
+    }
+    nvtxRangePop();  // Initialize memory demuxers
+
+    nvtxRangePushA("Packet extraction from bytes");
+    for (int i = 0; i < static_cast<int>(total_frames); ++i) {
+        try {
+            std::vector<int> sorted_frame_ids = {frame_ids[i]};
+            if (demuxers[i]->IsVFRV2()) {
+                int st = ExtractAndProcessGopInfo(demuxers[i], sorted_frame_ids, all_first_frame_ids[i],
+                                                  all_gop_lens[i]);
+                if (st != 0) {
+                    throw std::runtime_error("[ERROR] extract and process gop info failed for bytes source");
+                }
+            }
+#ifdef PROCESS_SYNC
+            DemuxGopProc(demuxers[i].get(), vpacket_queue[i].get(), sorted_frame_ids,
+                         all_first_frame_ids[i], all_gop_lens[i], vpacket_array[i], true);
+#else
+            demux_runners[i].join();
+            demux_runners[i].start(PyNvGopDecoder::DemuxGopProc, demuxers[i].get(), vpacket_queue[i].get(),
+                                   sorted_frame_ids, std::ref(all_first_frame_ids[i]),
+                                   std::ref(all_gop_lens[i]), std::ref(vpacket_array[i]), true);
+#endif
+        } catch (const std::exception& e) {
+            this->force_join_all();
+            nvtxRangePop();  // Packet extraction from bytes
+            nvtxRangePop();  // GetGOPFromBytes
+            throw std::runtime_error(e.what());
+        }
+    }
+    nvtxRangePop();  // Packet extraction from bytes
+
+    nvtxRangePushA("Demux thread join");
+    try {
+        for (int i = 0; i < static_cast<int>(total_frames); ++i) {
+#ifndef PROCESS_SYNC
+            demux_runners[i].join();
+#endif
+        }
+    } catch (const std::exception& e) {
+        this->force_join_all();
+        nvtxRangePop();  // Demux thread join
+        nvtxRangePop();  // GetGOPFromBytes
+        throw std::runtime_error(e.what());
+    }
+
+    for (int i = 0; i < static_cast<int>(total_frames); i++) {
+        if (vpacket_array.at(i).empty()) {
+            this->force_join_all();
+            nvtxRangePop();  // Demux thread join
+            nvtxRangePop();  // GetGOPFromBytes
+            throw std::runtime_error("[ERROR] vpacket_array is empty for bytes source");
+        }
+    }
+    nvtxRangePop();  // Demux thread join
+
+    nvtxRangePushA("CreateSerializedPacketBundle");
+    SerializedPacketBundle result = createSerializedPacketBundle(
+        total_frames, demuxers, all_gop_lens, all_first_frame_ids, vpacket_queue, vpacket_array);
+    nvtxRangePop();  // CreateSerializedPacketBundle
+
+    nvtxRangePop();  // GetGOPFromBytes
+    return result;
+}
+
 std::vector<SerializedPacketBundle> PyNvGopDecoder::get_gop_list(const std::vector<std::string>& filepaths,
                                                                  const std::vector<int> frame_ids,
                                                                  const FastStreamInfo* fastStreamInfos) {

--- a/packages/on_demand_video_decoder/ext_impl/src/PyNvOnDemandDecoder/src/PyNvGopDemuxer.cpp
+++ b/packages/on_demand_video_decoder/ext_impl/src/PyNvOnDemandDecoder/src/PyNvGopDemuxer.cpp
@@ -37,12 +37,12 @@ PyNvGopDemuxer::PyNvGopDemuxer(const std::string& filePath, const FastStreamInfo
     nvtxRangePop();
 }
 
-PyNvGopDemuxer::PyNvGopDemuxer(const std::string& sourceName,
+PyNvGopDemuxer::PyNvGopDemuxer(const std::string& filePath,
                                std::shared_ptr<const std::vector<uint8_t>> memoryData) {
     nvtxRangePushA("FFmpegDemuxer_Create_FromMemory");
     auto provider = std::make_shared<FFmpegDemuxer::MemoryDataProvider>(std::move(memoryData));
     demuxer.reset(new FFmpegDemuxer(std::move(provider)));
-    this->filename = sourceName;
+    this->filename = filePath;
     nvtxRangePop();
 }
 

--- a/packages/on_demand_video_decoder/ext_impl/src/PyNvOnDemandDecoder/src/PyNvGopDemuxer.cpp
+++ b/packages/on_demand_video_decoder/ext_impl/src/PyNvOnDemandDecoder/src/PyNvGopDemuxer.cpp
@@ -37,6 +37,15 @@ PyNvGopDemuxer::PyNvGopDemuxer(const std::string& filePath, const FastStreamInfo
     nvtxRangePop();
 }
 
+PyNvGopDemuxer::PyNvGopDemuxer(const std::string& sourceName,
+                               std::shared_ptr<const std::vector<uint8_t>> memoryData) {
+    nvtxRangePushA("FFmpegDemuxer_Create_FromMemory");
+    auto provider = std::make_shared<FFmpegDemuxer::MemoryDataProvider>(std::move(memoryData));
+    demuxer.reset(new FFmpegDemuxer(std::move(provider)));
+    this->filename = sourceName;
+    nvtxRangePop();
+}
+
 // Frame and PTS mapping methods
 void PyNvGopDemuxer::set_pts_frameid_mapping(std::map<int, int64_t>&& frame2pts,
                                              std::map<int64_t, int>&& pts2frame) {

--- a/packages/on_demand_video_decoder/ext_impl/src/VideoCodecSDKUtils/helper_classes/Utils/FFmpegDemuxer.h
+++ b/packages/on_demand_video_decoder/ext_impl/src/VideoCodecSDKUtils/helper_classes/Utils/FFmpegDemuxer.h
@@ -16,9 +16,15 @@
  
 #pragma once
 
+#include <algorithm>
+#include <cerrno>
+#include <cstdlib>
+#include <cstring>
+#include <memory>
+#include <vector>
+
 extern "C" {
 #include <fcntl.h>
-#include <cstdlib>
 #include <libavformat/avformat.h>
 #include <libavformat/avio.h>
 #include <libavcodec/avcodec.h>
@@ -481,9 +487,74 @@ class FFmpegDemuxer {
        public:
         virtual ~DataProvider() {}
         virtual int GetData(uint8_t* pBuf, int nBuf) = 0;
+        virtual int64_t Seek(int64_t offset, int whence) {
+            if (whence == AVSEEK_SIZE) {
+                return Size();
+            }
+            return AVERROR(ENOSYS);
+        }
+        virtual int64_t Size() const { return -1; }
+        virtual bool IsSeekable() const { return Size() >= 0; }
+    };
+
+    class MemoryDataProvider : public DataProvider {
+       public:
+        explicit MemoryDataProvider(std::shared_ptr<const std::vector<uint8_t>> data)
+            : data_(std::move(data)), pos_(0) {}
+
+        int GetData(uint8_t* pBuf, int nBuf) override {
+            if (!data_ || nBuf <= 0 || pos_ >= static_cast<int64_t>(data_->size())) {
+                return AVERROR_EOF;
+            }
+            int64_t remaining = static_cast<int64_t>(data_->size()) - pos_;
+            int bytes_to_copy = static_cast<int>(std::min<int64_t>(remaining, nBuf));
+            std::memcpy(pBuf, data_->data() + pos_, bytes_to_copy);
+            pos_ += bytes_to_copy;
+            return bytes_to_copy;
+        }
+
+        int64_t Seek(int64_t offset, int whence) override {
+            if (!data_) {
+                return AVERROR(EINVAL);
+            }
+            if (whence == AVSEEK_SIZE) {
+                return static_cast<int64_t>(data_->size());
+            }
+
+            int64_t new_pos = 0;
+            switch (whence) {
+                case SEEK_SET:
+                    new_pos = offset;
+                    break;
+                case SEEK_CUR:
+                    new_pos = pos_ + offset;
+                    break;
+                case SEEK_END:
+                    new_pos = static_cast<int64_t>(data_->size()) + offset;
+                    break;
+                default:
+                    return AVERROR(EINVAL);
+            }
+
+            if (new_pos < 0 || new_pos > static_cast<int64_t>(data_->size())) {
+                return AVERROR(EINVAL);
+            }
+            pos_ = new_pos;
+            return pos_;
+        }
+
+        int64_t Size() const override {
+            return data_ ? static_cast<int64_t>(data_->size()) : -1;
+        }
+
+       private:
+        std::shared_ptr<const std::vector<uint8_t>> data_;
+        int64_t pos_;
     };
 
    private:
+    std::shared_ptr<DataProvider> dataProvider = nullptr;
+
     void init(AVFormatContext* fmtc_, int64_t timeScale = 1000 /*Hz*/, const FastStreamInfo* fastStreamInfo = nullptr) {
         if (!fmtc_) {
             LOG(ERROR) << "No AVFormatContext provided.";
@@ -693,7 +764,8 @@ class FFmpegDemuxer {
 
         /* Some inputs doesn't allow seek functionality.
         * Check this ahead of time. */
-        is_seekable = fmtc->iformat->read_seek || fmtc->iformat->read_seek2;
+        bool avio_seekable = !fmtc->pb || (fmtc->pb->seekable & AVIO_SEEKABLE_NORMAL);
+        is_seekable = (fmtc->iformat->read_seek || fmtc->iformat->read_seek2) && avio_seekable;
     }
 
     /**
@@ -726,11 +798,15 @@ class FFmpegDemuxer {
             LOG(ERROR) << "FFmpeg error: " << __FILE__ << " " << __LINE__;
             return NULL;
         }
-        avioc =
-            avio_alloc_context(avioc_buffer, avioc_buffer_size, 0, pDataProvider, &ReadPacket, NULL, NULL);
+        int64_t (*seek_cb)(void*, int64_t, int) = pDataProvider->IsSeekable() ? &SeekPacket : NULL;
+        avioc = avio_alloc_context(avioc_buffer, avioc_buffer_size, 0, pDataProvider, &ReadPacket, NULL,
+                                   seek_cb);
         if (!avioc) {
             LOG(ERROR) << "FFmpeg error: " << __FILE__ << " " << __LINE__;
             return NULL;
+        }
+        if (pDataProvider->IsSeekable()) {
+            avioc->seekable = AVIO_SEEKABLE_NORMAL;
         }
         ctx->pb = avioc;
 
@@ -755,9 +831,18 @@ class FFmpegDemuxer {
    public:
     FFmpegDemuxer(const char *szFilePath, int64_t timescale = 1000 /*Hz*/) : FFmpegDemuxer(CreateFormatContext(szFilePath), timescale) {}
     FFmpegDemuxer(const char *szFilePath, const FastStreamInfo* fastStreamInfo, int64_t timescale = 1000 /*Hz*/) : FFmpegDemuxer(CreateFormatContext(szFilePath), fastStreamInfo, timescale) {}
-    
+
     FFmpegDemuxer(DataProvider* pDataProvider) : FFmpegDemuxer(CreateFormatContext(pDataProvider)) {
         avioc = fmtc->pb;
+    }
+
+    FFmpegDemuxer(std::shared_ptr<DataProvider> pDataProvider, int64_t timescale = 1000 /*Hz*/) {
+        dataProvider = std::move(pDataProvider);
+        AVFormatContext* ctx = CreateFormatContext(dataProvider.get());
+        avioc = ctx ? ctx->pb : nullptr;
+        nvtxRangePushA("init");
+        init(ctx, timescale);
+        nvtxRangePop();
     }
 
     FFmpegDemuxer(const char* szFilePath, int buf_size /*512*1024*/, int64_t timescale = 1000) {
@@ -1258,6 +1343,10 @@ class FFmpegDemuxer {
 
     static int ReadPacket(void* opaque, uint8_t* pBuf, int nBuf) {
         return ((DataProvider*)opaque)->GetData(pBuf, nBuf);
+    }
+
+    static int64_t SeekPacket(void* opaque, int64_t offset, int whence) {
+        return ((DataProvider*)opaque)->Seek(offset, whence);
     }
 };
 

--- a/packages/on_demand_video_decoder/ext_impl/src/VideoCodecSDKUtils/helper_classes/Utils/FFmpegDemuxer.h
+++ b/packages/on_demand_video_decoder/ext_impl/src/VideoCodecSDKUtils/helper_classes/Utils/FFmpegDemuxer.h
@@ -16,15 +16,9 @@
  
 #pragma once
 
-#include <algorithm>
-#include <cerrno>
-#include <cstdlib>
-#include <cstring>
-#include <memory>
-#include <vector>
-
 extern "C" {
 #include <fcntl.h>
+#include <cstdlib>
 #include <libavformat/avformat.h>
 #include <libavformat/avio.h>
 #include <libavcodec/avcodec.h>
@@ -35,6 +29,11 @@ extern "C" {
 #include <libavcodec/bsf.h>
 #endif
 }
+#include <algorithm>
+#include <cerrno>
+#include <cstring>
+#include <memory>
+#include <vector>
 #include "cuviddec.h"
 #include "nvcuvid.h"
 #include "NvCodecUtils.h"
@@ -487,6 +486,10 @@ class FFmpegDemuxer {
        public:
         virtual ~DataProvider() {}
         virtual int GetData(uint8_t* pBuf, int nBuf) = 0;
+    };
+
+    class SeekableDataProvider : public DataProvider {
+       public:
         virtual int64_t Seek(int64_t offset, int whence) {
             if (whence == AVSEEK_SIZE) {
                 return Size();
@@ -497,7 +500,7 @@ class FFmpegDemuxer {
         virtual bool IsSeekable() const { return Size() >= 0; }
     };
 
-    class MemoryDataProvider : public DataProvider {
+    class MemoryDataProvider : public SeekableDataProvider {
        public:
         explicit MemoryDataProvider(std::shared_ptr<const std::vector<uint8_t>> data)
             : data_(std::move(data)), pos_(0) {}
@@ -798,14 +801,16 @@ class FFmpegDemuxer {
             LOG(ERROR) << "FFmpeg error: " << __FILE__ << " " << __LINE__;
             return NULL;
         }
-        int64_t (*seek_cb)(void*, int64_t, int) = pDataProvider->IsSeekable() ? &SeekPacket : NULL;
+        SeekableDataProvider* pSeekableDataProvider = dynamic_cast<SeekableDataProvider*>(pDataProvider);
+        int64_t (*seek_cb)(void*, int64_t, int) =
+            pSeekableDataProvider && pSeekableDataProvider->IsSeekable() ? &SeekPacket : NULL;
         avioc = avio_alloc_context(avioc_buffer, avioc_buffer_size, 0, pDataProvider, &ReadPacket, NULL,
                                    seek_cb);
         if (!avioc) {
             LOG(ERROR) << "FFmpeg error: " << __FILE__ << " " << __LINE__;
             return NULL;
         }
-        if (pDataProvider->IsSeekable()) {
+        if (pSeekableDataProvider && pSeekableDataProvider->IsSeekable()) {
             avioc->seekable = AVIO_SEEKABLE_NORMAL;
         }
         ctx->pb = avioc;
@@ -1346,7 +1351,8 @@ class FFmpegDemuxer {
     }
 
     static int64_t SeekPacket(void* opaque, int64_t offset, int whence) {
-        return ((DataProvider*)opaque)->Seek(offset, whence);
+        auto* provider = dynamic_cast<SeekableDataProvider*>((DataProvider*)opaque);
+        return provider ? provider->Seek(offset, whence) : AVERROR(ENOSYS);
     }
 };
 

--- a/packages/on_demand_video_decoder/tests/test_shared_gop_store.py
+++ b/packages/on_demand_video_decoder/tests/test_shared_gop_store.py
@@ -142,6 +142,29 @@ class TestLifecycle:
         view = store.read(ref)
         np.testing.assert_array_equal(view, data)
 
+    def test_put_accepts_bytes(self, store):
+        """put() accepts raw bytes without requiring a numpy array wrapper."""
+        data = _make_gop_data(4096, seed=17)
+        ref = store.put("/video/bytes.mp4", 0, 30, data.tobytes())
+        view = store.read(ref)
+        np.testing.assert_array_equal(view, data)
+
+    def test_put_accepts_mutable_bytes_like_objects(self, store):
+        """put() accepts bytearray and memoryview GOP payloads."""
+        data0 = _make_gop_data(512, seed=18)
+        data1 = _make_gop_data(768, seed=19)
+
+        ref0 = store.put("/video/bytearray.mp4", 0, 30, bytearray(data0))
+        ref1 = store.put("/video/memoryview.mp4", 0, 30, memoryview(data1))
+
+        np.testing.assert_array_equal(store.read(ref0), data0)
+        np.testing.assert_array_equal(store.read(ref1), data1)
+
+    def test_put_rejects_empty_bytes(self, store):
+        """put() rejects empty payloads before allocating SharedMemory."""
+        with pytest.raises(ValueError, match="must not be empty"):
+            store.put("/video/empty.mp4", 0, 30, b"")
+
     def test_cleanup_removes_all_shm(self, store_id):
         """After cleanup(), no shm files remain for this store."""
         s = SharedGopStore.create(capacity=4, store_id=store_id)


### PR DESCRIPTION
  ## Description

  This change adds bytes-like buffer support to the on-demand video decoder GOP workflows.

  Specifically, it:
  - Allows `SharedGopStore.put()` to accept `bytes`, `bytearray`, and `memoryview` directly, in addition to `numpy.ndarray`.
  - Allows GOP decode bindings such as `DecodeFromGOP`, `DecodeFromGOPRGB`, `DecodeFromGOPListRGB`, and `DecodeFromPacketListRGB` to accept generic Python bytes-like buffers via `py::buffer`.
  - Keeps existing numpy-array based workflows compatible.

  This is needed for data pipelines where video/GOP packet data is already available as raw bytes, for example from record files, mmap slices, shared-memory buffers, or custom storage backends. It avoids
  requiring callers to wrap those payloads into numpy arrays before caching or decoding.

  Affected components:
  - `accvlab.on_demand_video_decoder`
  - `SharedGopStore`
  - `PyNvGopDecoder` Python bindings for GOP/packet decode paths

  Type of Change 选这个：

  - [ ] Bug fix (non-breaking change that fixes an issue)
  - [x] New feature (non-breaking change that adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to change)
  - [ ] Documentation / examples / tutorials / demos
  - [ ] Supporting functionality change (fix or feature in documentation generation, helper scripts, ...)
  - [ ] Refactoring / internal change
  - [ ] Other (please describe):

  Testing 可以写：

  - [x] Tests added or updated if/as needed
  - [ ] Repository test runner executed: `scripts/run_tests.sh`

  Added `SharedGopStore` tests for `bytes`, `bytearray`, `memoryview`, and empty byte payload validation.

  Validation performed locally:
  - `git diff --check`
  - Python compile check for updated Python files
  - Manual regression for bytes-like `SharedGopStore.put()` path
  - Minimal pybind11 extension compile/import check for `std::vector<py::buffer>` and nested buffer-list casting

  Full repository test runner was not executed because this local environment is missing pytest and the full native extension build is blocked by missing FFmpeg headers.

  Documentation / Code Quality 可以填：

  ## Documentation, Examples, Tutorials, Demos

  - [x] User-facing documentation updated if/as needed (including API docs)
  - [ ] Examples / tutorials / demos updated or added (if relevant)
  - [ ] Limitations and constraints documented (if relevant)
  - [ ] Performance documented (if relevant)
  - [ ] Documentation building successful & checks outlined in the Documentation Checks section are performed

  Updated pybind API docstrings to mention bytes-like inputs. No examples or performance docs were needed.

  ## Code Quality

  - [ ] Dependencies updated in the relevant `pyproject.toml` if/as needed
  - [x] Code formatted according to the Code Formatting Guide

  No dependency changes were required. `git diff --check` passed.
