### PR TITLE
Guard corrupt GOP packet handling

### DIFF
--- a/packages/on_demand_video_decoder/ext_impl/src/PyNvOnDemandDecoder/inc/GopDecoderUtils.hpp
+++ b/packages/on_demand_video_decoder/ext_impl/src/PyNvOnDemandDecoder/inc/GopDecoderUtils.hpp
@@ -412,6 +412,10 @@ inline std::vector<int> parse_gop_start_idx(FFmpegDemuxer* demuxer, std::map<int
         auto ret = demuxer->Demux(&pVideo, &nVideoBytes, &timestamp, &flags);
         ++frame_cnt;
 
+        if (!ret && demuxer->HasDemuxError()) {
+            throw std::invalid_argument("[ERROR] Demux error: " + demuxer->GetLastDemuxError());
+        }
+
         if (nVideoBytes) {
             if (!ret) {
                 throw std::invalid_argument("[ERROR] Demux error");

--- a/packages/on_demand_video_decoder/ext_impl/src/PyNvOnDemandDecoder/inc/PyNvGopDemuxer.hpp
+++ b/packages/on_demand_video_decoder/ext_impl/src/PyNvOnDemandDecoder/inc/PyNvGopDemuxer.hpp
@@ -47,6 +47,12 @@ class PyNvGopDemuxer {
 
     FFmpegDemuxer* GetDemuxer() { return demuxer.get(); }
 
+    bool HasDemuxError() const { return demuxer && demuxer->HasDemuxError(); }
+
+    std::string GetLastDemuxError() const { return demuxer ? demuxer->GetLastDemuxError() : ""; }
+
+    const std::string& GetFilename() const { return filename; }
+
     bool IsVFR() { return demuxer->IsVFR(); }
     bool IsVFRV2() { return demuxer->IsVFRV2(); }
 

--- a/packages/on_demand_video_decoder/ext_impl/src/PyNvOnDemandDecoder/src/PyNvGopDecoder_common.cpp
+++ b/packages/on_demand_video_decoder/ext_impl/src/PyNvOnDemandDecoder/src/PyNvGopDecoder_common.cpp
@@ -248,12 +248,18 @@ void PyNvGopDecoder::DemuxGopProc(PyNvGopDemuxer* demuxer,
         gop_lens.reserve(sorted_frame_ids.size());
     }
 
+    auto make_demux_error = [&](int target_frame_id, const std::string& reason) {
+        return "[ERROR] GOP demux failed for file: " + demuxer->GetFilename() +
+               " frame_id=" + std::to_string(target_frame_id) + ": " + reason;
+    };
+
     try {
         packet_array.reserve(std::accumulate(gop_lens.begin(), gop_lens.end(), 0));
         int nVideoBytes = 0;
         uint8_t* pVideo = NULL;
 
         for (int i = 0; i < sorted_frame_ids.size(); ++i) {
+            const int target_frame_id = sorted_frame_ids[i];
             bool seeking = true;
             int frame_id_out = 0;
             int key_frame_id = 0;
@@ -265,15 +271,24 @@ void PyNvGopDecoder::DemuxGopProc(PyNvGopDemuxer* demuxer,
             int gop_len = 0;
             do {
                 if (seeking) {
-                    if (seek_with_no_map) {
-                        ret = demuxer->SeekGopFirstFrameNoMap(&pVideo, &nVideoBytes, sorted_frame_ids[i],
-                                                              frame_id_out);
-                    } else {
-                        ret = demuxer->Seek(&pVideo, &nVideoBytes, first_frame_ids[i], frame_id_out);
+                    try {
+                        if (seek_with_no_map) {
+                            ret = demuxer->SeekGopFirstFrameNoMap(&pVideo, &nVideoBytes, sorted_frame_ids[i],
+                                                                  frame_id_out);
+                        } else {
+                            ret = demuxer->Seek(&pVideo, &nVideoBytes, first_frame_ids[i], frame_id_out);
+                        }
+                    } catch (const std::exception& e) {
+                        throw std::runtime_error(make_demux_error(target_frame_id, e.what()));
                     }
                     if (!ret) {
-                        throw std::out_of_range("[Error] Seeking for frame_id:" +
-                                                std::to_string(first_frame_ids[i]));
+                        int requested_frame_id = seek_with_no_map ? sorted_frame_ids[i] : first_frame_ids[i];
+                        std::string message =
+                            "[Error] Seeking for frame_id:" + std::to_string(requested_frame_id);
+                        if (demuxer->HasDemuxError()) {
+                            message += ": " + demuxer->GetLastDemuxError();
+                        }
+                        throw std::runtime_error(make_demux_error(target_frame_id, message));
                     }
                     seeking = false;
                     key_frame_id = frame_id_out;
@@ -281,14 +296,23 @@ void PyNvGopDecoder::DemuxGopProc(PyNvGopDemuxer* demuxer,
                         first_frame_ids.push_back(key_frame_id);
                     }
                 } else {
-                    auto ret = demuxer->Demux(&pVideo, &nVideoBytes, frame_id_out, &flags, &bRef);
-                    if (nVideoBytes) {
-                        if (!ret) {
-                            throw std::out_of_range("[Error] Demuxing");
+                    bool ret = false;
+                    try {
+                        ret = demuxer->Demux(&pVideo, &nVideoBytes, frame_id_out, &flags, &bRef);
+                    } catch (const std::exception& e) {
+                        throw std::runtime_error(make_demux_error(target_frame_id, e.what()));
+                    }
+                    if (!ret) {
+                        if (demuxer->HasDemuxError()) {
+                            throw std::runtime_error(make_demux_error(
+                                target_frame_id, "[ERROR] Demuxing failed: " + demuxer->GetLastDemuxError()));
                         }
-                    } else {
+                        if (nVideoBytes) {
+                            throw std::out_of_range(make_demux_error(target_frame_id, "[Error] Demuxing"));
+                        }
                         continue;
                     }
+                    if (!nVideoBytes) continue;
                     bool find_key_frame = iskeyFrame(demuxer->GetDemuxer()->GetVideoCodec(), pVideo, flags);
                     find_next_key_frame |= find_key_frame;
                     if (find_key_frame) next_key_frame_id = frame_id_out;
@@ -366,9 +390,10 @@ void PyNvGopDecoder::DemuxGopProc(PyNvGopDemuxer* demuxer,
             if (seek_with_no_map) gop_lens.push_back(gop_len);
         }
         packet_queue->push_back(std::make_tuple(nullptr, -1, 0));
-    } catch (const std::exception& e) {
+    } catch (...) {
         packet_queue->push_back(std::make_tuple(nullptr, -1, 0));
-        LOG(ERROR) << "DemuxGopProc failed: " << e.what();
+        nvtxRangePop();  //DemuxGopProc
+        throw;
     }
     nvtxRangePop();  //DemuxGopProc
 }

--- a/packages/on_demand_video_decoder/ext_impl/src/PyNvOnDemandDecoder/src/PyNvGopDemuxer.cpp
+++ b/packages/on_demand_video_decoder/ext_impl/src/PyNvOnDemandDecoder/src/PyNvGopDemuxer.cpp
@@ -82,6 +82,10 @@ bool PyNvGopDemuxer::Demux(uint8_t** ppVideo, int* pnVideoBytes, int& frame_id, 
     auto ret = demuxer->Demux(ppVideo, pnVideoBytes, &timestamp, pFlags);
 
     if (!ret) {
+        if (demuxer->HasDemuxError()) {
+            throw std::runtime_error("[ERROR] Demux failed for file: " + this->filename + ": " +
+                                     demuxer->GetLastDemuxError());
+        }
         return false;
     }
 

--- a/packages/on_demand_video_decoder/ext_impl/src/PyNvOnDemandDecoder/src/PyNvVideoReader.cpp
+++ b/packages/on_demand_video_decoder/ext_impl/src/PyNvOnDemandDecoder/src/PyNvVideoReader.cpp
@@ -60,6 +60,11 @@ void PyNvVideoReader::parse_keyframe_idx(std::vector<int>& key_frame_ids, std::m
         auto ret = cur_demuxer->Demux(&pVideo, &nVideoBytes, &timestamp, &flags);
         ++frame_cnt;
 
+        if (!ret && cur_demuxer->HasDemuxError()) {
+            throw std::invalid_argument("[ERROR] Demux error for file: " + this->filename + ": " +
+                                        cur_demuxer->GetLastDemuxError());
+        }
+
         if (nVideoBytes) {
             if (!ret) {
                 throw std::invalid_argument("[ERROR] Demux error");
@@ -378,6 +383,7 @@ void PyNvVideoReader::DemuxGopProc(PyNvGopDemuxer* demuxer,
     } catch (const std::exception& e) {
         nvtxRangePop();
         std::cerr << e.what() << std::endl;
+        throw;
     }
     nvtxRangePop();
 }

--- a/packages/on_demand_video_decoder/ext_impl/src/VideoCodecSDKUtils/helper_classes/Utils/FFmpegDemuxer.h
+++ b/packages/on_demand_video_decoder/ext_impl/src/VideoCodecSDKUtils/helper_classes/Utils/FFmpegDemuxer.h
@@ -33,6 +33,7 @@ extern "C" {
 #include "nvcuvid.h"
 #include "NvCodecUtils.h"
 #include "nvtx3/nvtx3.hpp"
+#include <string>
 using namespace std;
 //---------------------------------------------------------------------------
 //! \file FFmpegDemuxer.h
@@ -475,6 +476,19 @@ class FFmpegDemuxer {
     unsigned int frameCount = 0;
 
     FFBufferIO* ffbufIO = NULL;
+    bool demux_error = false;
+    std::string demux_error_message;
+
+    void ClearDemuxError() {
+        demux_error = false;
+        demux_error_message.clear();
+    }
+
+    void SetDemuxError(const std::string& message) {
+        demux_error = true;
+        demux_error_message = message;
+        LOG(ERROR) << message;
+    }
 
    public:
     class DataProvider {
@@ -908,6 +922,8 @@ class FFmpegDemuxer {
             return true;
     }
     bool IsValid() const { return fmtc != nullptr; }
+    bool HasDemuxError() const { return demux_error; }
+    const std::string& GetLastDemuxError() const { return demux_error_message; }
     int64_t TsFromTime(double ts_sec) {
         /* Internal timestamp representation is integer, so multiply to AV_TIME_BASE
          * and switch to fixed point precision arithmetics; */
@@ -941,7 +957,9 @@ class FFmpegDemuxer {
 
     bool Demux(uint8_t** ppVideo, int* pnVideoBytes, int64_t* pts = NULL, int* flag = NULL) {
         NVTX_SCOPED_RANGE("demux")
+        ClearDemuxError();
         if (!fmtc) {
+            SetDemuxError("No AVFormatContext provided for demux.");
             return false;
         }
 
@@ -956,6 +974,11 @@ class FFmpegDemuxer {
             av_packet_unref(pkt);
         }
         if (e < 0) {
+            if (e != AVERROR_EOF) {
+                SetDemuxError("FFmpeg read frame failed for codec " +
+                              std::string(avcodec_get_name(eVideoCodec)) +
+                              ", ret=" + std::to_string(e));
+            }
             return false;
         }
 
@@ -963,8 +986,34 @@ class FFmpegDemuxer {
             if (pktFiltered->data) {
                 av_packet_unref(pktFiltered);
             }
-            ck(av_bsf_send_packet(bsfc, pkt));
-            ck(av_bsf_receive_packet(bsfc, pktFiltered));
+            if (!bsfc) {
+                SetDemuxError("FFmpeg bitstream filter is not initialized for codec " +
+                              std::string(avcodec_get_name(eVideoCodec)));
+                av_packet_unref(pkt);
+                return false;
+            }
+
+            const int send_ret = av_bsf_send_packet(bsfc, pkt);
+            if (send_ret < 0) {
+                SetDemuxError("FFmpeg bitstream filter send failed for codec " +
+                              std::string(avcodec_get_name(eVideoCodec)) +
+                              ", ret=" + std::to_string(send_ret));
+                av_packet_unref(pkt);
+                return false;
+            }
+
+            const int recv_ret = av_bsf_receive_packet(bsfc, pktFiltered);
+            if (recv_ret < 0) {
+                SetDemuxError("FFmpeg bitstream filter receive failed for codec " +
+                              std::string(avcodec_get_name(eVideoCodec)) +
+                              ", ret=" + std::to_string(recv_ret));
+                return false;
+            }
+            if (!pktFiltered->data || pktFiltered->size <= 0) {
+                SetDemuxError("FFmpeg bitstream filter produced an empty packet for codec " +
+                              std::string(avcodec_get_name(eVideoCodec)));
+                return false;
+            }
             *ppVideo = pktFiltered->data;
             *pnVideoBytes = pktFiltered->size;
             if (pts) *pts = (int64_t)(pktFiltered->pts);
@@ -1074,6 +1123,14 @@ class FFmpegDemuxer {
             };
         };
 
+        auto demux_or_throw = [&](int64_t* out_pts) {
+            bool ret = Demux(ppVideo, pnVideoBytes, out_pts);
+            if (!ret) {
+                throw runtime_error(HasDemuxError() ? GetLastDemuxError()
+                                                    : "Demux returned no packet while seeking");
+            }
+        };
+
         /* This will seek for exact frame number;
          * Note that decoder may not be able to decode such frame; */
         auto seek_for_exact_frame = [&](PacketData& pkt_data, SeekContext& seek_ctx) {
@@ -1083,9 +1140,7 @@ class FFmpegDemuxer {
 
             int condition = 0;
             do {
-                if (!Demux(ppVideo, pnVideoBytes, &seek_ctx.out_frame_pts)) {
-                    break;
-                }
+                demux_or_throw(&seek_ctx.out_frame_pts);
                 condition = is_seek_done(pkt_data, seek_ctx);
 
                 // We've gone too far and need to seek backwards;
@@ -1114,7 +1169,7 @@ class FFmpegDemuxer {
             if (rv < 0) throw std::runtime_error("Failed to seek");
 
             avcodec_flush_buffers(codecContext);
-            Demux(ppVideo, pnVideoBytes, &seek_ctx.out_frame_pts);
+            demux_or_throw(&seek_ctx.out_frame_pts);
             seek_ctx.out_frame_duration = pktFiltered->duration;
         };
 
@@ -1122,7 +1177,7 @@ class FFmpegDemuxer {
         auto seek_for_prev_key_frame = [&](PacketData& pkt_data, SeekContext& seek_ctx) {
             seek_frame(seek_ctx, AVSEEK_FLAG_BACKWARD);
 
-            Demux(ppVideo, pnVideoBytes, &seek_ctx.out_frame_pts);
+            demux_or_throw(&seek_ctx.out_frame_pts);
             // seek_ctx.out_frame_pts = pkt_data.pts;
             seek_ctx.out_frame_duration = pkt_data.duration;
         };
@@ -1211,6 +1266,14 @@ class FFmpegDemuxer {
             };
         };
 
+        auto demux_or_throw = [&](int64_t* out_pts) {
+            bool ret = Demux(ppVideo, pnVideoBytes, out_pts);
+            if (!ret) {
+                throw runtime_error(HasDemuxError() ? GetLastDemuxError()
+                                                    : "Demux returned no packet while seeking");
+            }
+        };
+
         /* This will seek to nearest I-frame;
      * Idea is to seek to N'th exact frame and rewing to nearest I-frame; */
         auto seek_for_nearest_iframe = [&](PacketData& pkt_data, SeekContext& seek_ctx) {
@@ -1220,7 +1283,7 @@ class FFmpegDemuxer {
             if (rv < 0) throw std::runtime_error("Failed to seek");
 
             avcodec_flush_buffers(codecContext);
-            Demux(ppVideo, pnVideoBytes, &seek_ctx.out_frame_pts);
+            demux_or_throw(&seek_ctx.out_frame_pts);
             seek_ctx.out_frame_duration = pktFiltered->duration;
         };
 
@@ -1228,7 +1291,7 @@ class FFmpegDemuxer {
         auto seek_for_prev_key_frame = [&](PacketData& pkt_data, SeekContext& seek_ctx) {
             seek_frame(seek_ctx, AVSEEK_FLAG_BACKWARD);
 
-            Demux(ppVideo, pnVideoBytes, &seek_ctx.out_frame_pts);
+            demux_or_throw(&seek_ctx.out_frame_pts);
             // seek_ctx.out_frame_pts = pkt_data.pts;
             seek_ctx.out_frame_duration = pkt_data.duration;
         };

--- a/packages/on_demand_video_decoder/tests/test_corrupt_gop_demux.py
+++ b/packages/on_demand_video_decoder/tests/test_corrupt_gop_demux.py
@@ -1,0 +1,52 @@
+# Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+import pytest
+
+
+def test_corrupt_hevc_demux_raises_actionable_error():
+    """Regression guard for corrupt HEVC mdat packets in GetGOPList."""
+    video = (
+        Path(__file__).resolve().parents[1]
+        / "data"
+        / "pix_fmt_variants"
+        / "hevc_hvc1_yuv420p10le.mp4"
+    )
+
+    from accvlab.on_demand_video_decoder import CreateGopDecoder
+
+    raw = bytearray(video.read_bytes())
+    mdat_pos = raw.find(b"mdat")
+    if mdat_pos < 0:
+        raise RuntimeError("mdat box not found")
+
+    start = mdat_pos + 16
+    end = min(start + 512, len(raw))
+    for idx in range(start, end):
+        raw[idx] ^= 0xFF
+
+    with TemporaryDirectory() as tmpdir:
+        bad_video = Path(tmpdir) / "bad_hevc.mp4"
+        bad_video.write_bytes(raw)
+        decoder = CreateGopDecoder(maxfiles=8, iGpu=0)
+        for frame_id in (0, 1, 5, 10, 20, 30):
+            with pytest.raises(RuntimeError) as exc_info:
+                decoder.GetGOPList([str(bad_video)], [frame_id], useGOPCache=False)
+            output = str(exc_info.value)
+            assert "General error -1094995529" not in output
+            assert "FFmpeg bitstream filter receive failed" in output
+            assert "GOP demux failed" in output


### PR DESCRIPTION
## Description

`GetGOPList` silently returns a truncated GOP as success when an HEVC file's mdat is corrupt, because `DemuxGopProc` skips (continues on) demux failures that report zero bytes instead of propagating the error — so callers get incomplete packet data with no exception.

## Type of Change

Please select (at least one):
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation / examples / tutorials / demos
- [ ] Supporting functionality change (fix or feature in documentation generation, helper scripts, ...)
- [ ] Refactoring / internal change
- [ ] Other (please describe):

## Testing

Checklist for testing:
- [x] Tests added or updated if/as needed
- [ ] Repository test runner executed: `scripts/run_tests.sh`

Optionally, add a brief description.

## Documentation, Examples, Tutorials, Demos

Checklist for documentation:
- [ ] User-facing documentation updated if/as needed (including API docs)
- [ ] Examples / tutorials / demos updated or added (if relevant)
- [x] Limitations and constraints documented (if relevant)
- [ ] Performance documented (if relevant)
- [ ] Documentation building successful & checks outlined in the [Documentation Checks](/NVIDIA/ACCV-Lab/blob/main/docs/guides/CONTRIBUTION_GUIDE.md#documentation-checks) section of the [Contribution Guide](/NVIDIA/ACCV-Lab/blob/main/docs/guides/CONTRIBUTION_GUIDE.md) are performed

Optionally, add a brief description.

## Code Quality

Checklist for dependencies:
  - [ ] Dependencies updated in the relevant `pyproject.toml` if/as needed
  - [x] Code formatted according to the [Code Formatting Guide](/NVIDIA/ACCV-Lab/blob/main/docs/guides/FORMATTING_GUIDE.md)

Optionally, add a brief description.

## Related Issues / Context

If applicable, link related issues, discussions etc.

---

## DCO / Sign-Off

Please refer to the section on [Signing Your Work & Developer Certificate of Origin (DCO)](/NVIDIA/ACCV-Lab/blob/main/docs/guides/CONTRIBUTION_GUIDE.md#signing-your-work--developer-certificate-of-origin-dco)
in the Contribution Guide before submitting your contribution.

## References

For additional details, please refer to the [Contribution Guide](/NVIDIA/ACCV-Lab/blob/main/docs/guides/CONTRIBUTION_GUIDE.md).
The following guides are available (referenced in the Contribution Guide for further details):
- [`docs/guides/CONTRIBUTION_GUIDE.md`](/NVIDIA/ACCV-Lab/blob/main/docs/guides/CONTRIBUTION_GUIDE.md)
- [`docs/guides/DEVELOPMENT_GUIDE.md`](/NVIDIA/ACCV-Lab/blob/main/docs/guides/DEVELOPMENT_GUIDE.md)
- [`docs/guides/DOCUMENTATION_SETUP_GUIDE.md`](/NVIDIA/ACCV-Lab/blob/main/docs/guides/DOCUMENTATION_SETUP_GUIDE.md)
- [`docs/guides/FORMATTING_GUIDE.md`](/NVIDIA/ACCV-Lab/blob/main/docs/guides/FORMATTING_GUIDE.md)

Please also refer to the [summary checklist in the Contribution Guide](/NVIDIA/ACCV-Lab/blob/main/docs/guides/CONTRIBUTION_GUIDE.md#summary-checklist),
which is a guideline for what to consider when submitting your contribution and covers the same topics as the checklists above.
