### PR TITLE
Remove unused async decoder preallocations

### DIFF
--- a/packages/on_demand_video_decoder/ext_impl/src/VideoCodecSDKUtils/helper_classes/NvCodec/NvDecoder/NvDecoder.cpp
+++ b/packages/on_demand_video_decoder/ext_impl/src/VideoCodecSDKUtils/helper_classes/NvCodec/NvDecoder/NvDecoder.cpp
@@ -382,17 +382,6 @@ int NvDecoder::HandleVideoSequence(CUVIDEOFORMAT *pVideoFormat)
     }
     
     CUDA_DRVAPI_CALL(cuCtxPopCurrent(NULL));
-    uint8_t* pFrame[8] = { NULL };
-    if (m_bUseDeviceFrame)
-        {
-            if (m_bEnableAsyncAllocations)
-            {
-                for (size_t i = 0; i < 8; i++)
-                {
-                    CUDA_DRVAPI_CALL(cuMemAllocAsync((CUdeviceptr*)&pFrame[i], GetFrameSize(), m_cuvidStream));
-                }
-            }
-        }
     // STOP_TIMER("Session Initialization Time: ");
     // NvDecoder::addDecoderSessionOverHead(getDecoderSessionID(), elapsedTime);
     return nDecodeSurface;
@@ -515,18 +504,6 @@ int NvDecoder::ReconfigureDecoder(CUVIDEOFORMAT *pVideoFormat)
             }
         }
     }
-    //recreate new buffers
-    uint8_t* pFrame[8] = { NULL };
-    if (m_bUseDeviceFrame)
-        {
-            if (m_bEnableAsyncAllocations)
-            {
-                for (size_t i = 0; i < 8; i++)
-                {
-                    CUDA_DRVAPI_CALL(cuMemAllocAsync((CUdeviceptr*)&pFrame[i], GetFrameSize(), m_cuvidStream));
-                }
-            }
-        }
     CUDA_DRVAPI_CALL(cuCtxPopCurrent(NULL));
     STOP_TIMER("Session Reconfigure Time: ");
 


### PR DESCRIPTION
## Summary

Remove unused `cuMemAllocAsync` preallocations from `NvDecoder::HandleVideoSequence` and `NvDecoder::ReconfigureDecoder`.

These local `pFrame[8]` allocations are not stored in `m_vpFrame`, so they are not managed by the decoder frame lifecycle and cannot be released by the destructor. Output frame buffers are already allocated lazily in `HandlePictureDisplay` and tracked by `m_vpFrame`.

This is intended as a small cleanup/risk reduction before enabling `bEnableAsyncAllocations` in GOP decode paths.

## Verification

- `git diff --check`
