### PR TITLE
Fix for sporadically failing test in DALI Pipeline Framework

### DIFF
--- a/packages/dali_pipeline_framework/tests/processing_steps/bev_bboxes_transformer_3d_test.py
+++ b/packages/dali_pipeline_framework/tests/processing_steps/bev_bboxes_transformer_3d_test.py
@@ -34,6 +34,10 @@ from accvlab.dali_pipeline_framework.pipeline import (
 )
 from accvlab.dali_pipeline_framework.processing_steps import BEVBBoxesTransformer3D
 
+# Float32 transform matrices accumulate error across trigonometry, inversions, and matrix products.
+# 5e-6 is a small error budget for values with translation components in the tens.
+FLOAT32_TRANSFORM_MATRIX_TOLERANCE = 5e-6
+
 
 def set_dali_uniform_generator_and_get_orig_and_replacement(sequences):
     generator = DaliFakeRandomGenerator(sequences)
@@ -292,7 +296,9 @@ def apply_transformation_to_points(points, rotation_matrix, scaling_matrix, tran
     return res
 
 
-def verify_matrix_inverse_relationship(ego_to_world, world_to_ego, tolerance=1e-6):
+def verify_matrix_inverse_relationship(
+    ego_to_world, world_to_ego, tolerance=FLOAT32_TRANSFORM_MATRIX_TOLERANCE
+):
     """Verify that world_to_ego is the inverse of ego_to_world."""
 
     expected_world_to_ego = torch.linalg.inv(ego_to_world)
@@ -300,14 +306,6 @@ def verify_matrix_inverse_relationship(ego_to_world, world_to_ego, tolerance=1e-
         "world_to_ego does not match inv(ego_to_world). "
         f"Max difference: {torch.max(torch.abs(world_to_ego - expected_world_to_ego)).item()}"
     )
-
-    # Check that world_to_ego @ ego_to_world = identity
-    identity_check = world_to_ego @ ego_to_world
-    expected_identity = torch.eye(4, dtype=torch.float32)
-
-    assert torch.allclose(
-        identity_check, expected_identity, atol=tolerance
-    ), f"world_to_ego is not the inverse of ego_to_world. Max difference: {torch.max(torch.abs(identity_check - expected_identity)).item()}"
 
 
 def verify_transformation_consistency(
@@ -367,6 +365,7 @@ def verify(
     scaling,
     translation,
     tolerance=1e-6,
+    transform_matrix_tolerance=FLOAT32_TRANSFORM_MATRIX_TOLERANCE,
 ):
     """Verify that the transformation is consistent."""
 
@@ -422,18 +421,20 @@ def verify(
         ),
         dtype=torch.float32,
     )
-    assert torch.allclose(ego_to_world_ref, ego_to_world_out, atol=tolerance), (
+    assert torch.allclose(ego_to_world_ref, ego_to_world_out, atol=transform_matrix_tolerance), (
         "ego_to_world transformation does not match reference implementation. "
         f"Max difference: {torch.max(torch.abs(ego_to_world_ref - ego_to_world_out)).item()}"
     )
-    assert torch.allclose(world_to_ego_ref, world_to_ego_out, atol=tolerance), (
+    assert torch.allclose(world_to_ego_ref, world_to_ego_out, atol=transform_matrix_tolerance), (
         "world_to_ego transformation does not match reference implementation. "
         f"Max difference: {torch.max(torch.abs(world_to_ego_ref - world_to_ego_out)).item()}"
     )
 
     verify_transformation_consistency(points_in, proj_matrix_in, points_out, proj_matrix_out, tolerance)
     verify_transformation_consistency(points_in, ego_to_world_in, points_out, ego_to_world_out, tolerance)
-    verify_matrix_inverse_relationship(ego_to_world_out, world_to_ego_out, tolerance)
+    verify_matrix_inverse_relationship(
+        ego_to_world_out, world_to_ego_out, tolerance=transform_matrix_tolerance
+    )
 
 
 def run_transformation_test_with_reference_comparison(


### PR DESCRIPTION
## Description

- Test was sporadically failing due to tight error bounds for results of OPs involving matmuls & inverses
- Sporadically likely due to use of Numba with different CPUs
- Changes
  - Removed redundant check which introduced a longer computation chain (more error accumulation)
  - Slightly increased the tolerance for other related checks

## Type of Change

Please select (at least one):
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation / examples / tutorials / demos
- [ ] Supporting functionality change (fix or feature in documentation generation, helper scripts, ...)
- [ ] Refactoring / internal change
- [ ] Other (please describe):

## Testing

Checklist for testing:
- [x] Tests added or updated if/as needed
- [x] Repository test runner executed: `scripts/run_tests.sh`

Optionally, add a brief description.

## Documentation, Examples, Tutorials, Demos

Checklist for documentation:
- [ ] User-facing documentation updated if/as needed (including API docs)
- [ ] Examples / tutorials / demos updated or added (if relevant)
- [ ] Limitations and constraints documented (if relevant)
- [ ] Performance documented (if relevant)
- [ ] Documentation building successful & checks outlined in the [Documentation Checks](/NVIDIA/ACCV-Lab/blob/main/docs/guides/CONTRIBUTION_GUIDE.md#documentation-checks) section of the [Contribution Guide](/NVIDIA/ACCV-Lab/blob/main/docs/guides/CONTRIBUTION_GUIDE.md) are performed

Optionally, add a brief description.

## Code Quality

Checklist for dependencies:
  - [ ] Dependencies updated in the relevant `pyproject.toml` if/as needed
  - [x] Code formatted according to the [Code Formatting Guide](/NVIDIA/ACCV-Lab/blob/main/docs/guides/FORMATTING_GUIDE.md)

Optionally, add a brief description.

## Related Issues / Context

If applicable, link related issues, discussions etc.

---

## DCO / Sign-Off

Please refer to the section on [Signing Your Work & Developer Certificate of Origin (DCO)](/NVIDIA/ACCV-Lab/blob/main/docs/guides/CONTRIBUTION_GUIDE.md#signing-your-work--developer-certificate-of-origin-dco)
in the Contribution Guide before submitting your contribution.

## References

For additional details, please refer to the [Contribution Guide](/NVIDIA/ACCV-Lab/blob/main/docs/guides/CONTRIBUTION_GUIDE.md).
The following guides are available (referenced in the Contribution Guide for further details):
- [`docs/guides/CONTRIBUTION_GUIDE.md`](/NVIDIA/ACCV-Lab/blob/main/docs/guides/CONTRIBUTION_GUIDE.md)
- [`docs/guides/DEVELOPMENT_GUIDE.md`](/NVIDIA/ACCV-Lab/blob/main/docs/guides/DEVELOPMENT_GUIDE.md)
- [`docs/guides/DOCUMENTATION_SETUP_GUIDE.md`](/NVIDIA/ACCV-Lab/blob/main/docs/guides/DOCUMENTATION_SETUP_GUIDE.md)
- [`docs/guides/FORMATTING_GUIDE.md`](/NVIDIA/ACCV-Lab/blob/main/docs/guides/FORMATTING_GUIDE.md)

Please also refer to the [summary checklist in the Contribution Guide](/NVIDIA/ACCV-Lab/blob/main/docs/guides/CONTRIBUTION_GUIDE.md#summary-checklist),
which is a guideline for what to consider when submitting your contribution and covers the same topics as the checklists above.
