### PR TITLE
feat: support mps training

### DIFF
--- a/packages/on_demand_video_decoder/accvlab/on_demand_video_decoder/_mps/__init__.py
+++ b/packages/on_demand_video_decoder/accvlab/on_demand_video_decoder/_mps/__init__.py
@@ -1,0 +1,17 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .manager import MpsManager
+
+__all__ = ["MpsManager"]

--- a/packages/on_demand_video_decoder/accvlab/on_demand_video_decoder/_mps/launcher.py
+++ b/packages/on_demand_video_decoder/accvlab/on_demand_video_decoder/_mps/launcher.py
@@ -1,0 +1,59 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import signal
+import sys
+
+
+def mps_launch() -> None:
+    if len(sys.argv) < 2:
+        print("Usage: accvlab-mps <command> [args...]", file=sys.stderr)
+        sys.exit(1)
+
+    from .manager import MpsManager
+
+    MpsManager.start()
+
+    pid = os.fork()
+
+    if pid == 0:
+        # Child: replace this process with the user's command.
+        # execvpe wipes all Python state (including atexit), so the child starts clean.
+        try:
+            os.execvpe(sys.argv[1], sys.argv[1:], os.environ)
+        except OSError as e:
+            print(f"accvlab-mps: {e}", file=sys.stderr)
+        os._exit(127)
+
+    # Parent: sole job is to forward signals and stop the daemon when the child exits.
+    def _forward(sig: int, _frame) -> None:
+        try:
+            os.kill(pid, sig)
+        except ProcessLookupError:
+            pass
+
+    # SIGHUP/SIGTERM are sent to this PID directly — forward to child.
+    signal.signal(signal.SIGHUP, _forward)
+    signal.signal(signal.SIGTERM, _forward)
+    # SIGINT/SIGQUIT come from the terminal to the whole process group,
+    # so the child already receives them; parent ignores to avoid racing.
+    signal.signal(signal.SIGINT, signal.SIG_IGN)
+    signal.signal(signal.SIGQUIT, signal.SIG_IGN)
+
+    _, status = os.waitpid(pid, 0)
+
+    MpsManager.stop()
+
+    sys.exit(os.waitstatus_to_exitcode(status))

--- a/packages/on_demand_video_decoder/accvlab/on_demand_video_decoder/_mps/manager.py
+++ b/packages/on_demand_video_decoder/accvlab/on_demand_video_decoder/_mps/manager.py
@@ -1,0 +1,81 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import atexit
+import os
+import subprocess
+import time
+
+
+class MpsManager:
+    _started: bool = False
+    _pipe_dir: str = ""
+
+    @classmethod
+    def _pipe_directory(cls) -> str:
+        if not cls._pipe_dir:
+            uid = os.getuid()
+            job_id = os.environ.get("SLURM_JOB_ID", "")
+            suffix = f"-{job_id}" if job_id else ""
+            cls._pipe_dir = f"/tmp/accvlab-mps-{uid}{suffix}"
+        return cls._pipe_dir
+
+    @classmethod
+    def start(cls) -> None:
+        if cls._started:
+            return
+        pipe_dir = cls._pipe_directory()
+        log_dir = pipe_dir.replace("accvlab-mps-", "accvlab-log-", 1)
+        os.makedirs(pipe_dir, exist_ok=True)
+        os.makedirs(log_dir, exist_ok=True)
+        os.environ["CUDA_MPS_PIPE_DIRECTORY"] = pipe_dir
+        os.environ["CUDA_MPS_LOG_DIRECTORY"] = log_dir
+        os.environ["ACCVLAB_MPS_LEVEL"] = "task"
+        if not cls._is_running():
+            subprocess.Popen(["nvidia-cuda-mps-control", "-d"])
+            deadline = time.monotonic() + 5.0
+            while time.monotonic() < deadline:
+                if cls._is_running():
+                    break
+                time.sleep(0.05)
+            else:
+                raise RuntimeError("nvidia-cuda-mps-control daemon failed to start within 5s")
+        atexit.register(cls.stop)
+        cls._started = True
+
+    @classmethod
+    def stop(cls) -> None:
+        if not cls._started:
+            return
+        cls._started = False
+        subprocess.run(
+            ["nvidia-cuda-mps-control"],
+            input=b"quit\n",
+            capture_output=True,
+            env=os.environ.copy(),
+            timeout=5,
+            check=False,
+        )
+
+    @classmethod
+    def _is_running(cls) -> bool:
+        r = subprocess.run(
+            ["nvidia-cuda-mps-control"],
+            input=b"get_server_list\n",
+            capture_output=True,
+            env=os.environ.copy(),
+            timeout=2,
+            check=False,
+        )
+        return r.returncode == 0

--- a/packages/on_demand_video_decoder/docs/index.rst
+++ b/packages/on_demand_video_decoder/docs/index.rst
@@ -14,4 +14,5 @@ This documentation contains the following sections:
    api
    sample
    pytorch_integration_examples/index
+   mps_optimization
    evaluation

--- a/packages/on_demand_video_decoder/docs/mps_optimization.md
+++ b/packages/on_demand_video_decoder/docs/mps_optimization.md
@@ -1,0 +1,72 @@
+# MPS Optimization
+
+## Why MPS
+
+A typical PyTorch training setup uses a `DataLoader` with multiple worker processes for video decoding.
+Each worker process creates its own CUDA context. When several CUDA contexts share the same GPU, the
+driver serializes them through time-slicing: only one context runs at a time, and switching between
+them has measurable overhead.
+
+During the forward and backward pass, the training process and the decoder workers compete for the GPU.
+The decoder workers interrupt the training compute, and the training process interrupts the decoder
+workers in return. The result is that both sides run slower than they would in isolation.
+
+CUDA MPS (Multi-Process Service) addresses this by running a single server-side CUDA context on behalf
+of all client processes. The MPS server multiplexes their work onto the GPU without time-slicing,
+allowing the NVDEC decoder and the SM compute to overlap genuinely.
+
+## Quick Start
+
+### Managed by accvlab (recommended)
+
+`accvlab-mps` starts the MPS daemon before the training process and shuts it down when training exits.
+No changes to the training script are needed.
+
+```bash
+# Single-GPU
+accvlab-mps python train.py
+
+# Multi-GPU with torchrun
+accvlab-mps torchrun --nproc_per_node=8 train.py
+```
+
+### Manual startup
+
+Start and stop the MPS daemon yourself, without relying on accvlab:
+
+```bash
+# Start
+export CUDA_MPS_PIPE_DIRECTORY=/tmp/my-mps
+mkdir -p $CUDA_MPS_PIPE_DIRECTORY
+nvidia-cuda-mps-control -d
+
+# Run training — the process picks up CUDA_MPS_PIPE_DIRECTORY automatically
+python train.py
+
+# Stop
+echo quit | nvidia-cuda-mps-control
+```
+
+> **⚠️ Warning**: If the training process exits without running the `quit` command, the MPS daemon
+> keeps running in the background. Subsequent processes that inherit `CUDA_MPS_PIPE_DIRECTORY` will
+> continue to connect to it. Stop it explicitly when it is no longer needed.
+
+## Requirements
+
+- `nvidia-cuda-mps-control` in `PATH` (ships with the CUDA toolkit)
+- GPU compute mode set to **Default** or **Exclusive_Process**
+  (`nvidia-smi -c 0` for Default, `nvidia-smi -c 3` for Exclusive_Process)
+- Linux only
+
+## Limitations
+
+- **Windows is not supported.** `accvlab-mps` relies on `fork`/`exec`, which is not available on Windows.
+- MPS has the following general constraints; consult the official documentation for the full list:
+  - CUDA debuggers (`cuda-gdb`, `compute-sanitizer`) are not compatible with MPS.
+  - All MPS clients must run as the same OS user.
+  - If the MPS server crashes, all client processes lose their CUDA context and cannot recover.
+  - A small subset of CUDA APIs are not supported under MPS.
+
+## References
+
+- [NVIDIA MPS documentation](https://docs.nvidia.com/deploy/mps/index.html)

--- a/packages/on_demand_video_decoder/setup.py
+++ b/packages/on_demand_video_decoder/setup.py
@@ -62,4 +62,9 @@ skbuild.setup(
     cmake_source_dir="ext_impl",
     cmake_install_dir="accvlab/on_demand_video_decoder",
     cmake_args=_cmake_args,
+    entry_points={
+        "console_scripts": [
+            "accvlab-mps = accvlab.on_demand_video_decoder._mps.launcher:mps_launch",
+        ],
+    },
 )

--- a/packages/on_demand_video_decoder/tests/test_mps.py
+++ b/packages/on_demand_video_decoder/tests/test_mps.py
@@ -1,0 +1,179 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import signal
+import sys
+import unittest
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+from accvlab.on_demand_video_decoder._mps.manager import MpsManager
+
+
+@pytest.fixture(autouse=True)
+def reset_manager():
+    MpsManager._started = False
+    MpsManager._pipe_dir = ""
+    yield
+    MpsManager._started = False
+    MpsManager._pipe_dir = ""
+
+
+class TestMpsManager:
+    def test_start_idempotent(self):
+        with (
+            patch.object(MpsManager, "_is_running", return_value=True),
+            patch("subprocess.Popen") as mock_popen,
+            patch("atexit.register"),
+            patch("os.makedirs"),
+        ):
+            MpsManager.start()
+            MpsManager.start()
+
+        mock_popen.assert_not_called()
+
+    def test_start_raises_on_daemon_timeout(self):
+        with (
+            patch.object(MpsManager, "_is_running", return_value=False),
+            patch("subprocess.Popen"),
+            patch("os.makedirs"),
+            patch("time.sleep"),
+            patch("time.monotonic", side_effect=[0.0, 0.1, 5.1]),
+        ):
+            with pytest.raises(RuntimeError, match="failed to start within 5s"):
+                MpsManager.start()
+
+    def test_stop_clears_started_before_subprocess(self):
+        # If subprocess.run raises, _started must already be False so atexit
+        # doesn't call stop() a second time and send a duplicate quit.
+        MpsManager._started = True
+        call_order = []
+
+        def record_started(*_args, **_kwargs):
+            call_order.append(("subprocess", MpsManager._started))
+            raise RuntimeError("simulated subprocess failure")
+
+        with patch("subprocess.run", side_effect=record_started):
+            with pytest.raises(RuntimeError):
+                MpsManager.stop()
+
+        assert call_order == [("subprocess", False)]
+
+    @pytest.mark.parametrize(
+        "job_id, expected_suffix",
+        [
+            ("42", "-42"),
+            ("", ""),
+        ],
+    )
+    def test_pipe_dir_with_and_without_slurm_job_id(self, job_id, expected_suffix, monkeypatch):
+        if job_id:
+            monkeypatch.setenv("SLURM_JOB_ID", job_id)
+        else:
+            monkeypatch.delenv("SLURM_JOB_ID", raising=False)
+
+        pipe_dir = MpsManager._pipe_directory()
+        uid = os.getuid()
+
+        assert pipe_dir == f"/tmp/accvlab-mps-{uid}{expected_suffix}"
+
+
+class TestMpsLauncher:
+    def test_no_args_exits_with_usage(self, monkeypatch, capsys):
+        monkeypatch.setattr(sys, "argv", ["accvlab-mps"])
+
+        from accvlab.on_demand_video_decoder._mps.launcher import mps_launch
+
+        with pytest.raises(SystemExit) as exc_info:
+            mps_launch()
+
+        assert exc_info.value.code == 1
+        assert "Usage:" in capsys.readouterr().err
+
+    def test_child_execvpe_oserror_exits_127(self, monkeypatch, capsys):
+        monkeypatch.setattr(sys, "argv", ["accvlab-mps", "nonexistent-command"])
+        monkeypatch.setattr(os, "fork", lambda: 0)  # simulate child
+        monkeypatch.setattr(os, "execvpe", MagicMock(side_effect=OSError("No such file or directory")))
+        exit_called_with = []
+
+        def fake_os_exit(code):
+            exit_called_with.append(code)
+            raise SystemExit(code)
+
+        monkeypatch.setattr(os, "_exit", fake_os_exit)
+
+        with patch.object(MpsManager, "start"):
+            from accvlab.on_demand_video_decoder._mps import launcher
+
+            with pytest.raises(SystemExit):
+                launcher.mps_launch()
+
+        assert exit_called_with == [127]
+        assert "accvlab-mps:" in capsys.readouterr().err
+
+    def test_sigint_sigquit_set_to_ign(self, monkeypatch):
+        monkeypatch.setattr(sys, "argv", ["accvlab-mps", "true"])
+        monkeypatch.setattr(os, "fork", lambda: 99)  # simulate parent
+        monkeypatch.setattr(os, "waitpid", lambda _pid, _flags: (99, 0))
+
+        recorded_handlers = {}
+
+        original_signal = signal.signal
+
+        def capture_signal(sig, handler):
+            recorded_handlers[sig] = handler
+            return original_signal(sig, handler)
+
+        monkeypatch.setattr(signal, "signal", capture_signal)
+
+        with (
+            patch.object(MpsManager, "start"),
+            patch.object(MpsManager, "stop"),
+            patch("sys.exit"),
+        ):
+            from accvlab.on_demand_video_decoder._mps import launcher
+
+            launcher.mps_launch()
+
+        assert recorded_handlers.get(signal.SIGINT) is signal.SIG_IGN
+        assert recorded_handlers.get(signal.SIGQUIT) is signal.SIG_IGN
+
+    def test_exit_code_propagation(self, monkeypatch):
+        monkeypatch.setattr(sys, "argv", ["accvlab-mps", "true"])
+        monkeypatch.setattr(os, "fork", lambda: 99)
+
+        # os.waitstatus_to_exitcode(exit_status) where exit_status encodes exit code 3:
+        # a normal exit is encoded as (exit_code << 8).
+        exit_code = 3
+        wait_status = exit_code << 8
+        monkeypatch.setattr(os, "waitpid", lambda _pid, _flags: (99, wait_status))
+
+        captured_exit = []
+        monkeypatch.setattr(sys, "exit", lambda code: captured_exit.append(code))
+
+        with (
+            patch.object(MpsManager, "start"),
+            patch.object(MpsManager, "stop"),
+        ):
+            from accvlab.on_demand_video_decoder._mps import launcher
+
+            launcher.mps_launch()
+
+        assert captured_exit == [exit_code]
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Description

Adds a new `accvlab-mps` CLI wrapper that starts an NVIDIA Multi-Process Service daemon before launching a training command and shuts it down cleanly on exit, enabling GPU time-sharing between the video-decode workers and the training process without any code changes to existing scripts.

## Type of Change

Please select (at least one):
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation / examples / tutorials / demos
- [ ] Supporting functionality change (fix or feature in documentation generation, helper scripts, ...)
- [ ] Refactoring / internal change
- [ ] Other (please describe):

## Testing

Checklist for testing:
- [x] Tests added or updated if/as needed
- [ ] Repository test runner executed: `scripts/run_tests.sh`

Optionally, add a brief description.

## Documentation, Examples, Tutorials, Demos

Checklist for documentation:
- [x] User-facing documentation updated if/as needed (including API docs)
- [ ] Examples / tutorials / demos updated or added (if relevant)
- [ ] Limitations and constraints documented (if relevant)
- [ ] Performance documented (if relevant)
- [ ] Documentation building successful & checks outlined in the [Documentation Checks](/NVIDIA/ACCV-Lab/blob/main/docs/guides/CONTRIBUTION_GUIDE.md#documentation-checks) section of the [Contribution Guide](/NVIDIA/ACCV-Lab/blob/main/docs/guides/CONTRIBUTION_GUIDE.md) are performed

Optionally, add a brief description.

## Code Quality

Checklist for dependencies:
  - [ ] Dependencies updated in the relevant `pyproject.toml` if/as needed
  - [ ] Code formatted according to the [Code Formatting Guide](/NVIDIA/ACCV-Lab/blob/main/docs/guides/FORMATTING_GUIDE.md)

Optionally, add a brief description.

## Related Issues / Context

If applicable, link related issues, discussions etc.

---

## DCO / Sign-Off

Please refer to the section on [Signing Your Work & Developer Certificate of Origin (DCO)](/NVIDIA/ACCV-Lab/blob/main/docs/guides/CONTRIBUTION_GUIDE.md#signing-your-work--developer-certificate-of-origin-dco)
in the Contribution Guide before submitting your contribution.

## References

For additional details, please refer to the [Contribution Guide](/NVIDIA/ACCV-Lab/blob/main/docs/guides/CONTRIBUTION_GUIDE.md).
The following guides are available (referenced in the Contribution Guide for further details):
- [`docs/guides/CONTRIBUTION_GUIDE.md`](/NVIDIA/ACCV-Lab/blob/main/docs/guides/CONTRIBUTION_GUIDE.md)
- [`docs/guides/DEVELOPMENT_GUIDE.md`](/NVIDIA/ACCV-Lab/blob/main/docs/guides/DEVELOPMENT_GUIDE.md)
- [`docs/guides/DOCUMENTATION_SETUP_GUIDE.md`](/NVIDIA/ACCV-Lab/blob/main/docs/guides/DOCUMENTATION_SETUP_GUIDE.md)
- [`docs/guides/FORMATTING_GUIDE.md`](/NVIDIA/ACCV-Lab/blob/main/docs/guides/FORMATTING_GUIDE.md)

Please also refer to the [summary checklist in the Contribution Guide](/NVIDIA/ACCV-Lab/blob/main/docs/guides/CONTRIBUTION_GUIDE.md#summary-checklist),
which is a guideline for what to consider when submitting your contribution and covers the same topics as the checklists above.
