### PR TITLE
Fixed issue where CUDA arch was not set correctly for CMake projects using torch.

### DIFF
--- a/build_config/accvlab_build_config/helpers/__init__.py
+++ b/build_config/accvlab_build_config/helpers/__init__.py
@@ -26,6 +26,8 @@ from .build_utils import (
     get_abs_setup_dir,
 )
 from .cmake_args import (
+    CUDA_ARCH_STRATEGY_CMAKE,
+    CUDA_ARCH_STRATEGY_TORCH,
     build_cmake_args,
     get_project_root,
 )
@@ -38,6 +40,8 @@ __all__ = [
     'select_cuda_architectures_for_nvcc',
     'run_external_build',
     'get_abs_setup_dir',
+    'CUDA_ARCH_STRATEGY_CMAKE',
+    'CUDA_ARCH_STRATEGY_TORCH',
     'build_cmake_args',
     'get_project_root',
 ]

--- a/build_config/accvlab_build_config/helpers/build_utils.py
+++ b/build_config/accvlab_build_config/helpers/build_utils.py
@@ -169,7 +169,7 @@ def select_cuda_architectures_for_nvcc(
     return CudaArchitectureSelection(selected_archs, ptx_archs)
 
 
-def missing_torch_error() -> RuntimeError:
+def _missing_torch_error() -> RuntimeError:
     return RuntimeError("""
 #########################################################################################
 # Missing build dependency: torch.                                                      #
@@ -185,7 +185,7 @@ def missing_torch_error() -> RuntimeError:
 """)
 
 
-def require_torch_cuda_support(torch_module) -> None:
+def _require_torch_cuda_support(torch_module) -> None:
     if getattr(torch_module.version, "cuda", None) is not None:
         return
 
@@ -279,7 +279,7 @@ def detect_cuda_info():
     try:
         import torch
 
-        require_torch_cuda_support(torch)
+        _require_torch_cuda_support(torch)
 
         if torch.cuda.is_available():
             cuda_info['cuda_available'] = True
@@ -291,9 +291,135 @@ def detect_cuda_info():
                 if arch not in cuda_info['gpu_architectures']:
                     cuda_info['gpu_architectures'].append(arch)
     except ImportError as exc:
-        raise missing_torch_error() from exc
+        raise _missing_torch_error() from exc
 
     return cuda_info
+
+
+def _format_torch_cuda_arch_list(architectures: List[str]) -> str:
+    """Convert compact CUDA architecture numbers to ``TORCH_CUDA_ARCH_LIST`` format.
+
+    Args:
+        architectures: CUDA architecture numbers in compact form, for example
+            ``["90"]``, ``["103"]``, or ``["120a"]``.
+
+    Returns:
+        str: Semicolon-separated architecture names in PyTorch format, for
+        example ``"9.0"`` or ``"9.0;10.3"``.
+    """
+    formatted: List[str] = []
+    for arch in architectures:
+        arch = arch.strip()
+        if not arch:
+            continue
+        if re.match(r"^\d+\.\d", arch):
+            formatted.append(arch)
+            continue
+
+        match = re.match(r"^(\d+)([a-z]?)$", arch)
+        if not match:
+            formatted.append(arch)
+            continue
+
+        digits, suffix = match.group(1), match.group(2)
+        if len(digits) == 1:
+            formatted.append(f"{digits}.0{suffix}")
+        else:
+            formatted.append(f"{digits[:-1]}.{digits[-1]}{suffix}")
+
+    seen = set()
+    unique: List[str] = []
+    for item in formatted:
+        if item not in seen:
+            seen.add(item)
+            unique.append(item)
+    return ";".join(unique)
+
+
+def resolve_cuda_architecture_selection(
+    cuda_info: dict,
+) -> Optional[CudaArchitectureSelection]:
+    """Resolve cubin and PTX targets from ``CUSTOM_CUDA_ARCHS`` or auto-detection.
+
+    When ``CUSTOM_CUDA_ARCHS`` is set, architectures are passed through unchanged
+    without ``nvcc`` fallback rewriting. Otherwise detected GPU architectures are
+    mapped to exact cubin targets when supported, with PTX fallbacks when not.
+
+    Args:
+        cuda_info: CUDA information from ``detect_cuda_info()``.
+
+    Returns:
+        Optional[CudaArchitectureSelection]: Selected cubin and PTX targets, or
+        ``None`` when CUDA is unavailable and ``CUSTOM_CUDA_ARCHS`` is unset.
+    """
+    custom_archs = os.environ.get("CUSTOM_CUDA_ARCHS")
+    if custom_archs:
+        return CudaArchitectureSelection(_split_cuda_architectures(custom_archs), [])
+
+    if not cuda_info.get("cuda_available"):
+        return None
+
+    detected = cuda_info.get("gpu_architectures") or []
+    if not detected:
+        return None
+
+    return select_cuda_architectures_for_nvcc(detected)
+
+
+def format_torch_cuda_arch_list_from_selection(
+    selection: CudaArchitectureSelection,
+) -> str:
+    """Format an architecture selection for PyTorch ``TORCH_CUDA_ARCH_LIST``.
+
+    Args:
+        selection: Cubin and PTX targets from ``resolve_cuda_architecture_selection()``
+            or ``select_cuda_architectures_for_nvcc()``.
+
+    Returns:
+        str: Semicolon-separated PyTorch architecture names. PTX fallbacks use
+        the ``+PTX`` suffix.
+    """
+    arch_names: List[str] = []
+    for arch in selection.architectures:
+        arch_names.append(_format_torch_cuda_arch_list([arch]))
+    for arch in selection.ptx_architectures:
+        arch_names.append(f"{_format_torch_cuda_arch_list([arch])}+PTX")
+
+    seen = set()
+    unique: List[str] = []
+    for item in arch_names:
+        if item not in seen:
+            seen.add(item)
+            unique.append(item)
+    return ";".join(unique)
+
+
+def _resolve_torch_cuda_arch_list(cuda_info: Optional[dict] = None) -> Optional[str]:
+    """Resolve ``TORCH_CUDA_ARCH_LIST`` for PyTorch CMake extension builds.
+
+    PyTorch's CMake integration ignores ``CMAKE_CUDA_ARCHITECTURES`` and uses
+    ``TORCH_CUDA_ARCH_LIST`` instead. Uses the same architecture selection rules
+    as ``resolve_cuda_architecture_selection()``.
+
+    Args:
+        cuda_info: CUDA information from ``detect_cuda_info()``. When ``None``,
+            CUDA info is detected automatically.
+
+    Returns:
+        Optional[str]: Formatted ``TORCH_CUDA_ARCH_LIST`` value, or ``None`` when
+        no architectures can be resolved.
+    """
+    if cuda_info is None:
+        cuda_info = detect_cuda_info()
+
+    selection = resolve_cuda_architecture_selection(cuda_info)
+    if selection is None:
+        return None
+
+    if not selection.architectures and not selection.ptx_architectures:
+        return None
+
+    return format_torch_cuda_arch_list_from_selection(selection)
 
 
 def get_compile_flags(config, cuda_info, include_dirs=None):

--- a/build_config/accvlab_build_config/helpers/cmake_args.py
+++ b/build_config/accvlab_build_config/helpers/cmake_args.py
@@ -3,12 +3,20 @@ import re
 from pathlib import Path
 from typing import List, Optional
 
-from .build_utils import detect_cuda_info, select_cuda_architectures_for_nvcc
+from .build_utils import (
+    detect_cuda_info,
+    format_torch_cuda_arch_list_from_selection,
+    resolve_cuda_architecture_selection,
+)
 
 # Marker file at the ACCV-Lab monorepo root (see `.nav` in the repository).
 _NAV_MARKER = ".nav"
 # Must match `.nav` contents after strip (UTF-8); see repository root `.nav`.
 _NAV_EXPECTED_CONTENT = "project root"
+
+CUDA_ARCH_STRATEGY_CMAKE = "cmake"
+CUDA_ARCH_STRATEGY_TORCH = "torch"
+_VALID_CUDA_ARCH_STRATEGIES = frozenset({CUDA_ARCH_STRATEGY_CMAKE, CUDA_ARCH_STRATEGY_TORCH})
 
 
 def _nav_file_is_valid(path: Path) -> bool:
@@ -69,6 +77,33 @@ def _format_cmake_cuda_architectures(archs: List[str], ptx_archs: List[str]) -> 
     return cmake_archs
 
 
+def _append_cmake_cuda_architectures_args(args: List[str], cuda_info: dict) -> None:
+    selection = resolve_cuda_architecture_selection(cuda_info)
+    if selection is None:
+        return
+
+    cmake_archs = _format_cmake_cuda_architectures(
+        selection.architectures,
+        selection.ptx_architectures,
+    )
+    if not cmake_archs:
+        return
+
+    args.append(f'-DCMAKE_CUDA_ARCHITECTURES={";".join(cmake_archs)}')
+
+
+def _append_torch_cuda_arch_list_args(args: List[str], cuda_info: dict) -> None:
+    selection = resolve_cuda_architecture_selection(cuda_info)
+    if selection is None:
+        return
+
+    torch_cuda_arch_list = format_torch_cuda_arch_list_from_selection(selection)
+    if not torch_cuda_arch_list:
+        return
+
+    args.append(f"-DACCVLAB_TORCH_CUDA_ARCH_LIST={torch_cuda_arch_list}")
+
+
 def get_project_root() -> Path:
     """Return the ACCV-Lab monorepo root identified by a valid ``.nav`` marker."""
     anchors = (
@@ -89,15 +124,22 @@ def get_project_root() -> Path:
     )
 
 
-def _build_cmake_args_from_env() -> List[str]:
+def _build_cmake_args_from_env(cuda_arch_strategy: str) -> List[str]:
     """
     Build a list of -D CMake arguments from environment variables to harmonize
     build configuration across setuptools, external CMake, and scikit-build flows.
 
-    If ``CUSTOM_CUDA_ARCHS`` is unset, detected CUDA architectures become CMake
-    real targets only when ``nvcc`` reports exact support. Unsupported
-    detections use supported virtual/PTX targets at or below the detected
-    architecture.
+    CUDA architecture flags are prepared according to ``cuda_arch_strategy``:
+
+    - ``cmake``: ``-DCMAKE_CUDA_ARCHITECTURES=...``
+    - ``torch``: ``-DACCVLAB_TORCH_CUDA_ARCH_LIST=...`` for skbuild packages that
+      call ``find_package(Torch)`` (copied to ``TORCH_CUDA_ARCH_LIST`` in CMake)
+
+    If ``CUSTOM_CUDA_ARCHS`` is unset, detected CUDA architectures become real
+    targets only when ``nvcc`` reports exact support. Unsupported detections use
+    supported PTX targets at or below the detected architecture. When set,
+    ``CUSTOM_CUDA_ARCHS`` is passed through unchanged (see the Installation
+    Guide).
     """
     args: List[str] = []
     # Always export compile_commands.json for tooling/validation
@@ -117,23 +159,11 @@ def _build_cmake_args_from_env() -> List[str]:
             args.append(f"-DCMAKE_CXX_STANDARD={norm}")
             args.append(f"-DCMAKE_CUDA_STANDARD={norm}")
 
-    # CUSTOM_CUDA_ARCHS -> CMAKE_CUDA_ARCHITECTURES
-    custom_archs = os.environ.get("CUSTOM_CUDA_ARCHS")
-    if custom_archs:
-        # Accept comma or semicolon separated
-        norm_archs = custom_archs.replace(",", ";")
-        args.append(f'-DCMAKE_CUDA_ARCHITECTURES={norm_archs}')
-    else:
-        # Attempt auto-detection via torch; if empty, let CMake defaults apply
-        cuda_info = detect_cuda_info()
-        detected = cuda_info['gpu_architectures'] if cuda_info['cuda_available'] else []
-        if detected:
-            selection = select_cuda_architectures_for_nvcc(detected)
-            cmake_archs = _format_cmake_cuda_architectures(
-                selection.architectures,
-                selection.ptx_architectures,
-            )
-            args.append(f'-DCMAKE_CUDA_ARCHITECTURES={";".join(cmake_archs)}')
+    cuda_info = detect_cuda_info()
+    if cuda_arch_strategy == CUDA_ARCH_STRATEGY_CMAKE:
+        _append_cmake_cuda_architectures_args(args, cuda_info)
+    elif cuda_arch_strategy == CUDA_ARCH_STRATEGY_TORCH:
+        _append_torch_cuda_arch_list_args(args, cuda_info)
 
     # VERBOSE_BUILD -> CMAKE_VERBOSE_MAKEFILE
     if _parse_bool_env(os.environ.get("VERBOSE_BUILD", "")):
@@ -192,19 +222,40 @@ def _build_cmake_args_package_scm_version(repo_root: Path) -> List[str]:
     return [f"-DACCVLAB_PACKAGE_CMAKE_VERSION={numeric}"]
 
 
-def build_cmake_args() -> List[str]:
-    """
-    Full CMake -D list: environment-based flags plus repo-aligned SCM version define.
+def build_cmake_args(cuda_arch_strategy: str) -> List[str]:
+    """Build the full CMake ``-D`` argument list for ACCV-Lab package builds.
 
+    Combines environment-based build flags with a repo-aligned SCM version define.
     Auto-detected CUDA architectures use exact ``nvcc`` real targets when
     supported. Unsupported detections fall back to supported PTX targets at or
     below the detected architecture when ``CUSTOM_CUDA_ARCHS`` is unset.
+
+    Args:
+        cuda_arch_strategy: Select how CUDA GPU architectures are passed to CMake.
+            Pass ``CUDA_ARCH_STRATEGY_CMAKE`` for native CMake CUDA targets, or
+            ``CUDA_ARCH_STRATEGY_TORCH`` for skbuild packages that call
+            ``find_package(Torch)``. Each package's ``setup.py`` must choose the
+            strategy appropriate to its build.
+
+    Returns:
+        List[str]: CMake ``-D`` arguments derived from environment variables and
+        the repository SCM version.
     """
+    if cuda_arch_strategy not in _VALID_CUDA_ARCH_STRATEGIES:
+        valid = ", ".join(sorted(_VALID_CUDA_ARCH_STRATEGIES))
+        raise ValueError(f"Invalid cuda_arch_strategy {cuda_arch_strategy!r}; expected one of: {valid}")
     root = get_project_root()
-    return _build_cmake_args_from_env() + _build_cmake_args_package_scm_version(root)
+    res = _build_cmake_args_from_env(cuda_arch_strategy) + _build_cmake_args_package_scm_version(root)
+    return res
 
 
 if __name__ == "__main__":
+    import sys
+
+    if len(sys.argv) != 2:
+        valid = ", ".join(sorted(_VALID_CUDA_ARCH_STRATEGIES))
+        raise SystemExit(f"usage: {sys.argv[0]} <{valid}>")
+
     # Print arguments one per line for easy consumption in bash arrays
-    for a in build_cmake_args():
+    for a in build_cmake_args(sys.argv[1]):
         print(a)

--- a/build_config/tests/test_cuda_arch_selection.py
+++ b/build_config/tests/test_cuda_arch_selection.py
@@ -2,6 +2,7 @@ import unittest
 from unittest import mock
 
 from accvlab_build_config.helpers import build_utils
+from accvlab_build_config.helpers import cmake_args
 
 
 class CudaArchSelectionTest(unittest.TestCase):
@@ -67,6 +68,128 @@ class CudaArchSelectionTest(unittest.TestCase):
 
         self.assertEqual(selection.architectures, ["103"])
         self.assertEqual(selection.ptx_architectures, [])
+
+    def test_format_torch_cuda_arch_list_converts_compact_numbers(self):
+        self.assertEqual(build_utils._format_torch_cuda_arch_list(["90"]), "9.0")
+        self.assertEqual(build_utils._format_torch_cuda_arch_list(["103"]), "10.3")
+        self.assertEqual(build_utils._format_torch_cuda_arch_list(["120a"]), "12.0a")
+        self.assertEqual(
+            build_utils._format_torch_cuda_arch_list(["90", "103"]),
+            "9.0;10.3",
+        )
+
+    def test_resolve_torch_cuda_arch_list_uses_custom_cuda_archs(self):
+        with mock.patch.dict(
+            "os.environ",
+            {"CUSTOM_CUDA_ARCHS": "103"},
+            clear=False,
+        ):
+            resolved = build_utils._resolve_torch_cuda_arch_list(
+                {"cuda_available": True, "gpu_architectures": ["90"]}
+            )
+        self.assertEqual(resolved, "10.3")
+
+    def test_resolve_cuda_architecture_selection_uses_custom_cuda_archs(self):
+        with mock.patch.dict(
+            "os.environ",
+            {"CUSTOM_CUDA_ARCHS": "70,75,80"},
+            clear=False,
+        ):
+            with mock.patch.object(
+                build_utils,
+                "select_cuda_architectures_for_nvcc",
+                side_effect=AssertionError("unexpected selector call"),
+            ):
+                selection = build_utils.resolve_cuda_architecture_selection(
+                    {"cuda_available": True, "gpu_architectures": ["90"]}
+                )
+        self.assertEqual(selection, build_utils.CudaArchitectureSelection(["70", "75", "80"], []))
+
+    def test_build_cmake_args_custom_cuda_archs_cmake_strategy(self):
+        cuda_info = {"cuda_available": True, "gpu_architectures": ["90"]}
+        with mock.patch.dict("os.environ", {"CUSTOM_CUDA_ARCHS": "70,75,80"}, clear=False):
+            with mock.patch.object(cmake_args, "detect_cuda_info", return_value=cuda_info):
+                with mock.patch.object(
+                    build_utils,
+                    "select_cuda_architectures_for_nvcc",
+                    side_effect=AssertionError("unexpected selector call"),
+                ):
+                    with mock.patch.object(
+                        cmake_args,
+                        "_build_cmake_args_package_scm_version",
+                        return_value=[],
+                    ):
+                        args = cmake_args.build_cmake_args(
+                            cuda_arch_strategy=cmake_args.CUDA_ARCH_STRATEGY_CMAKE
+                        )
+
+        self.assertIn("-DCMAKE_CUDA_ARCHITECTURES=70;75;80", "\n".join(args))
+
+    def test_build_cmake_args_custom_cuda_archs_torch_strategy(self):
+        cuda_info = {"cuda_available": True, "gpu_architectures": ["90"]}
+        with mock.patch.dict("os.environ", {"CUSTOM_CUDA_ARCHS": "70,75,80"}, clear=False):
+            with mock.patch.object(cmake_args, "detect_cuda_info", return_value=cuda_info):
+                with mock.patch.object(
+                    build_utils,
+                    "select_cuda_architectures_for_nvcc",
+                    side_effect=AssertionError("unexpected selector call"),
+                ):
+                    with mock.patch.object(
+                        cmake_args,
+                        "_build_cmake_args_package_scm_version",
+                        return_value=[],
+                    ):
+                        args = cmake_args.build_cmake_args(
+                            cuda_arch_strategy=cmake_args.CUDA_ARCH_STRATEGY_TORCH
+                        )
+
+        self.assertIn("-DACCVLAB_TORCH_CUDA_ARCH_LIST=7.0;7.5;8.0", "\n".join(args))
+
+    def test_resolve_torch_cuda_arch_list_uses_detected_real_arch(self):
+        with mock.patch.dict("os.environ", {}, clear=True):
+            with self._mock_supported_architectures(["80", "90", "100"]):
+                resolved = build_utils._resolve_torch_cuda_arch_list(
+                    {"cuda_available": True, "gpu_architectures": ["90"]}
+                )
+        self.assertEqual(resolved, "9.0")
+
+    def test_resolve_torch_cuda_arch_list_adds_ptx_for_unsupported_arch(self):
+        with mock.patch.dict("os.environ", {}, clear=True):
+            with self._mock_supported_architectures(["100", "120"]):
+                resolved = build_utils._resolve_torch_cuda_arch_list(
+                    {"cuda_available": True, "gpu_architectures": ["103"]}
+                )
+        self.assertEqual(resolved, "10.0+PTX")
+
+    def test_build_cmake_args_cmake_strategy_emits_cmake_architectures(self):
+        cuda_info = {"cuda_available": True, "gpu_architectures": ["90"]}
+        with mock.patch.object(cmake_args, "detect_cuda_info", return_value=cuda_info):
+            with self._mock_supported_architectures(["80", "90", "100"]):
+                with mock.patch.object(
+                    cmake_args,
+                    "_build_cmake_args_package_scm_version",
+                    return_value=[],
+                ):
+                    args = cmake_args.build_cmake_args(cuda_arch_strategy=cmake_args.CUDA_ARCH_STRATEGY_CMAKE)
+
+        joined = "\n".join(args)
+        self.assertIn("-DCMAKE_CUDA_ARCHITECTURES=90", joined)
+        self.assertNotIn("-DACCVLAB_TORCH_CUDA_ARCH_LIST=", joined)
+
+    def test_build_cmake_args_torch_strategy_emits_torch_arch_list(self):
+        cuda_info = {"cuda_available": True, "gpu_architectures": ["90"]}
+        with mock.patch.object(cmake_args, "detect_cuda_info", return_value=cuda_info):
+            with self._mock_supported_architectures(["80", "90", "100"]):
+                with mock.patch.object(
+                    cmake_args,
+                    "_build_cmake_args_package_scm_version",
+                    return_value=[],
+                ):
+                    args = cmake_args.build_cmake_args(cuda_arch_strategy=cmake_args.CUDA_ARCH_STRATEGY_TORCH)
+
+        joined = "\n".join(args)
+        self.assertIn("-DACCVLAB_TORCH_CUDA_ARCH_LIST=9.0", joined)
+        self.assertNotIn("-DCMAKE_CUDA_ARCHITECTURES=", joined)
 
     def test_explicit_custom_architectures_are_not_rewritten(self):
         with mock.patch.object(

--- a/docs/guides/DEVELOPMENT_GUIDE.md
+++ b/docs/guides/DEVELOPMENT_GUIDE.md
@@ -776,11 +776,16 @@ The `accvlab_build_config` package provides the following shared build & configu
   build configuration error.
 - `get_compile_flags()` - Generates compiler flags for PyTorch extensions; based on the variable values obtained from 
   `load_config()`. The generated flags can then be passed to the PyTorch extensions (see example below).
-- `build_cmake_args()` - Produces the full CMake `-D` argument list for CMake-based builds. It contains two parts:
+- `build_cmake_args(cuda_arch_strategy)` - Produces the full CMake `-D` argument list for CMake-based builds.
+  Each CMake package, whether manual or scikit-build, must pass `CUDA_ARCH_STRATEGY_CMAKE` or
+  `CUDA_ARCH_STRATEGY_TORCH` depending on whether its `CMakeLists.txt` uses native CMake CUDA targets or
+  `find_package(Torch)`. It contains two parts:
   - **Environment-derived build settings**: Converts ACCV-Lab build variables into CMake cache entries:
     - `DEBUG_BUILD` → `CMAKE_BUILD_TYPE`
     - `CPP_STANDARD` → `CMAKE_CXX_STANDARD`, `CMAKE_CUDA_STANDARD`
-    - `CUSTOM_CUDA_ARCHS` → `CMAKE_CUDA_ARCHITECTURES`
+    - `CUSTOM_CUDA_ARCHS` → `CMAKE_CUDA_ARCHITECTURES` when using `CUDA_ARCH_STRATEGY_CMAKE`, or
+      `-DACCVLAB_TORCH_CUDA_ARCH_LIST=...` when using `CUDA_ARCH_STRATEGY_TORCH`. Torch CMake projects must
+      set `TORCH_CUDA_ARCH_LIST` from that cache variable before `find_package(Torch)`.
     - `VERBOSE_BUILD` → `CMAKE_VERBOSE_MAKEFILE`
     - `OPTIMIZE_LEVEL`, `USE_FAST_MATH`, `ENABLE_PROFILING` → appended to `CMAKE_CXX_FLAGS`, `CMAKE_CUDA_FLAGS`
     - Always sets `-DCMAKE_EXPORT_COMPILE_COMMANDS=ON`
@@ -877,12 +882,16 @@ Depending on the package type, build variables are consumed as follows:
     `USE_FAST_MATH`, and `ENABLE_PROFILING` to host and device compilers.
 
 - External implementation (manual CMake):
-  - In `ext_impl/build_and_copy.sh`, forward variables using the helper to produce `cmake -D` args:
+  - In `ext_impl/build_and_copy.sh`, forward variables using the helper to produce `cmake -D` args. Use
+    `CUDA_ARCH_STRATEGY_CMAKE` for native CMake CUDA targets, or `CUDA_ARCH_STRATEGY_TORCH` when
+    `CMakeLists.txt` calls `find_package(Torch)`:
   ```bash
-  readarray -t CMAKE_ARGS < <(python -c "from accvlab_build_config.helpers.cmake_args import build_cmake_args; print('\n'.join(build_cmake_args()))")
+  readarray -t CMAKE_ARGS < <(python -c "from accvlab_build_config.helpers.cmake_args import build_cmake_args, CUDA_ARCH_STRATEGY_CMAKE; print('\n'.join(build_cmake_args(CUDA_ARCH_STRATEGY_CMAKE)))")
   cmake .. "${CMAKE_ARGS[@]}" ...
   cmake --build . --parallel
   ```
+  - For Torch CMake projects, replace `CUDA_ARCH_STRATEGY_CMAKE` in the import and call with
+    `CUDA_ARCH_STRATEGY_TORCH`.
   - In `CMakeLists.txt`, avoid hardcoding and guard defaults so passed values win:
   ```cmake
   if(NOT DEFINED CMAKE_CXX_STANDARD)
@@ -892,15 +901,23 @@ Depending on the package type, build variables are consumed as follows:
     set(CMAKE_CUDA_ARCHITECTURES native)
   endif()
   ```
+  - If the CMake project calls `find_package(Torch)`, set the Torch architecture list before that call:
+  ```cmake
+  if(DEFINED ACCVLAB_TORCH_CUDA_ARCH_LIST)
+    set(TORCH_CUDA_ARCH_LIST "${ACCVLAB_TORCH_CUDA_ARCH_LIST}")
+  endif()
+  find_package(Torch REQUIRED)
+  ```
 
 - Scikit-build packages:
-  - In `setup.py`, pass CMake arguments from the helper:
+  - In `setup.py`, pass CMake arguments from the helper. Use `CUDA_ARCH_STRATEGY_CMAKE` for native CMake CUDA
+    targets, or `CUDA_ARCH_STRATEGY_TORCH` when `ext_impl/CMakeLists.txt` calls `find_package(Torch)`:
   ```python
   # The real setup.py files wrap this import in a guarded block with a prominent
   # missing-dependency message. The message body is omitted here for brevity.
-  from accvlab_build_config import build_cmake_args
+  from accvlab_build_config import build_cmake_args, CUDA_ARCH_STRATEGY_CMAKE
 
-  _cmake_args = build_cmake_args()
+  _cmake_args = build_cmake_args(cuda_arch_strategy=CUDA_ARCH_STRATEGY_CMAKE)
   setup(
       ...,
       cmake_source_dir="ext_impl",
@@ -908,6 +925,8 @@ Depending on the package type, build variables are consumed as follows:
       cmake_args=_cmake_args,
   )
   ```
+  - For Torch CMake projects, replace `CUDA_ARCH_STRATEGY_CMAKE` in the import and call with
+    `CUDA_ARCH_STRATEGY_TORCH`.
   - In `ext_impl/CMakeLists.txt`, guard defaults:
   ```cmake
   if(NOT DEFINED CMAKE_CXX_STANDARD)
@@ -916,6 +935,13 @@ Depending on the package type, build variables are consumed as follows:
   if(NOT DEFINED CMAKE_CUDA_ARCHITECTURES)
     set(CMAKE_CUDA_ARCHITECTURES native)
   endif()
+  ```
+  - If the CMake project calls `find_package(Torch)`, set the Torch architecture list before that call:
+  ```cmake
+  if(DEFINED ACCVLAB_TORCH_CUDA_ARCH_LIST)
+    set(TORCH_CUDA_ARCH_LIST "${ACCVLAB_TORCH_CUDA_ARCH_LIST}")
+  endif()
+  find_package(Torch REQUIRED)
   ```
 
 

--- a/docs/guides/INSTALLATION_GUIDE.md
+++ b/docs/guides/INSTALLATION_GUIDE.md
@@ -424,12 +424,15 @@ ENABLE_PROFILING=1 ./scripts/package_manager.sh install
 > architecture, preferring base architectures whose number is divisible by 10 (for example, `100` for a
 > detected `103` architecture).
 >
-> `CUSTOM_CUDA_ARCHS` is an explicit override. When it is set, ACCV-Lab passes those architectures through
-> unchanged instead of applying the auto-detection fallback logic.
+> `CUSTOM_CUDA_ARCHS` is an explicit override. When it is set, ACCV-Lab uses those architectures instead
+> of applying the auto-detection fallback logic. CMake builds that call `find_package(Torch)` receive
+> `-DACCVLAB_TORCH_CUDA_ARCH_LIST=...`, with compact ACCV-Lab values converted to PyTorch format
+> (for example, `90` becomes `9.0`) and set as `TORCH_CUDA_ARCH_LIST` in CMake. Other CMake-based builds
+> receive `CMAKE_CUDA_ARCHITECTURES` instead.
 >
 > If PyTorch is CUDA-enabled but no architecture can be detected
-> (for example because no CUDA device is visible), ACCV-Lab does not pass `CMAKE_CUDA_ARCHITECTURES`;
-> package-specific CMake defaults then apply.
+> (for example because no CUDA device is visible), ACCV-Lab does not pass an explicit CUDA architecture
+> setting; package-specific CMake defaults then apply.
 
 ## Additional Information
 

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -216,3 +216,8 @@ Polyline
 polyline
 Polylines
 polylines
+Runtimes
+runtimes
+Untracked
+untracked
+

--- a/packages/dali_pipeline_framework/setup.py
+++ b/packages/dali_pipeline_framework/setup.py
@@ -32,13 +32,13 @@ _ACCVLAB_BUILD_CONFIG_IMPORT_ERROR = """
 """
 
 try:
-    from accvlab_build_config import build_cmake_args  # type: ignore
+    from accvlab_build_config import build_cmake_args, CUDA_ARCH_STRATEGY_CMAKE  # type: ignore
 except ModuleNotFoundError as exc:
     if exc.name != "accvlab_build_config":
         raise
     raise RuntimeError(_ACCVLAB_BUILD_CONFIG_IMPORT_ERROR) from exc
 
-_cmake_args = build_cmake_args()
+_cmake_args = build_cmake_args(cuda_arch_strategy=CUDA_ARCH_STRATEGY_CMAKE)
 
 
 setup(

--- a/packages/example_package/ext_impl/CMakeLists.txt
+++ b/packages/example_package/ext_impl/CMakeLists.txt
@@ -23,6 +23,12 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 # Find CUDA
 find_package(CUDA REQUIRED)
 
+# PyTorch CMake ignores CMAKE_CUDA_ARCHITECTURES and uses TORCH_CUDA_ARCH_LIST.
+# build_and_copy.sh passes cuda_arch_strategy=TORCH via build_cmake_args().
+if(DEFINED ACCVLAB_TORCH_CUDA_ARCH_LIST)
+  set(TORCH_CUDA_ARCH_LIST "${ACCVLAB_TORCH_CUDA_ARCH_LIST}")
+endif()
+
 # Find PyTorch
 find_package(Torch REQUIRED)
 

--- a/packages/example_package/ext_impl/build_and_copy.sh
+++ b/packages/example_package/ext_impl/build_and_copy.sh
@@ -43,7 +43,7 @@ then
     exit 1
 fi
 # Read helper-produced cmake -D args into array
-readarray -t CMAKE_ARGS < <(python -c "from accvlab_build_config.helpers.cmake_args import build_cmake_args; print('\n'.join(build_cmake_args()))")
+readarray -t CMAKE_ARGS < <(python -c "from accvlab_build_config.helpers.cmake_args import build_cmake_args, CUDA_ARCH_STRATEGY_TORCH; print('\n'.join(build_cmake_args(CUDA_ARCH_STRATEGY_TORCH)))")
 
 # Configure CMake
 echo "Configuring CMake..."

--- a/packages/example_skbuild_package/ext_impl/CMakeLists.txt
+++ b/packages/example_skbuild_package/ext_impl/CMakeLists.txt
@@ -33,6 +33,12 @@ list(APPEND CMAKE_PREFIX_PATH "${TORCH_CMAKE_PATH}")
 # Find CUDA
 find_package(CUDA REQUIRED)
 
+# PyTorch CMake ignores CMAKE_CUDA_ARCHITECTURES and uses TORCH_CUDA_ARCH_LIST.
+# setup.py passes cuda_arch_strategy=TORCH via build_cmake_args().
+if(DEFINED ACCVLAB_TORCH_CUDA_ARCH_LIST)
+  set(TORCH_CUDA_ARCH_LIST "${ACCVLAB_TORCH_CUDA_ARCH_LIST}")
+endif()
+
 # Find PyTorch
 find_package(Torch REQUIRED)
 

--- a/packages/example_skbuild_package/setup.py
+++ b/packages/example_skbuild_package/setup.py
@@ -32,13 +32,13 @@ _ACCVLAB_BUILD_CONFIG_IMPORT_ERROR = """
 """
 
 try:
-    from accvlab_build_config import build_cmake_args  # type: ignore
+    from accvlab_build_config import build_cmake_args, CUDA_ARCH_STRATEGY_TORCH  # type: ignore
 except ModuleNotFoundError as exc:
     if exc.name != "accvlab_build_config":
         raise
     raise RuntimeError(_ACCVLAB_BUILD_CONFIG_IMPORT_ERROR) from exc
 
-_cmake_args = build_cmake_args()
+_cmake_args = build_cmake_args(cuda_arch_strategy=CUDA_ARCH_STRATEGY_TORCH)
 
 
 setup(

--- a/packages/lane_helpers/ext_impl/CMakeLists.txt
+++ b/packages/lane_helpers/ext_impl/CMakeLists.txt
@@ -28,6 +28,12 @@ execute_process(
 
 list(APPEND CMAKE_PREFIX_PATH "${TORCH_CMAKE_PATH}")
 
+# PyTorch CMake ignores CMAKE_CUDA_ARCHITECTURES and uses TORCH_CUDA_ARCH_LIST.
+# lane_helpers/setup.py passes cuda_arch_strategy=TORCH via build_cmake_args().
+if(DEFINED ACCVLAB_TORCH_CUDA_ARCH_LIST)
+  set(TORCH_CUDA_ARCH_LIST "${ACCVLAB_TORCH_CUDA_ARCH_LIST}")
+endif()
+
 find_package(CUDA REQUIRED)
 find_package(Torch REQUIRED)
 find_package(Python COMPONENTS Interpreter Development REQUIRED)

--- a/packages/lane_helpers/setup.py
+++ b/packages/lane_helpers/setup.py
@@ -32,13 +32,13 @@ _ACCVLAB_BUILD_CONFIG_IMPORT_ERROR = """
 """
 
 try:
-    from accvlab_build_config import build_cmake_args
+    from accvlab_build_config import build_cmake_args, CUDA_ARCH_STRATEGY_TORCH
 except ModuleNotFoundError as exc:
     if exc.name != "accvlab_build_config":
         raise
     raise RuntimeError(_ACCVLAB_BUILD_CONFIG_IMPORT_ERROR) from exc
 
-_cmake_args = build_cmake_args()
+_cmake_args = build_cmake_args(cuda_arch_strategy=CUDA_ARCH_STRATEGY_TORCH)
 
 
 setup(

--- a/packages/on_demand_video_decoder/setup.py
+++ b/packages/on_demand_video_decoder/setup.py
@@ -39,7 +39,7 @@ _ACCVLAB_BUILD_CONFIG_IMPORT_ERROR = """
 """
 
 try:
-    from accvlab_build_config import build_cmake_args  # type: ignore
+    from accvlab_build_config import build_cmake_args, CUDA_ARCH_STRATEGY_CMAKE  # type: ignore
 except ModuleNotFoundError as exc:
     if exc.name != "accvlab_build_config":
         raise
@@ -51,7 +51,7 @@ except VersionConflict:
     print("Error: version of setuptools is too old (<42)!")
     sys.exit(1)
 
-_cmake_args = build_cmake_args()
+_cmake_args = build_cmake_args(cuda_arch_strategy=CUDA_ARCH_STRATEGY_CMAKE)
 
 skbuild.setup(
     name="accvlab.on_demand_video_decoder",

--- a/packages/optim_test_tools/setup.py
+++ b/packages/optim_test_tools/setup.py
@@ -32,13 +32,13 @@ _ACCVLAB_BUILD_CONFIG_IMPORT_ERROR = """
 """
 
 try:
-    from accvlab_build_config import build_cmake_args
+    from accvlab_build_config import build_cmake_args, CUDA_ARCH_STRATEGY_CMAKE
 except ModuleNotFoundError as exc:
     if exc.name != "accvlab_build_config":
         raise
     raise RuntimeError(_ACCVLAB_BUILD_CONFIG_IMPORT_ERROR) from exc
 
-_cmake_args = build_cmake_args()
+_cmake_args = build_cmake_args(cuda_arch_strategy=CUDA_ARCH_STRATEGY_CMAKE)
 
 setup(
     name="accvlab.optim_test_tools",


### PR DESCRIPTION
- Added possibility to get an intermediate CMake variable from the build_config package with arch in torch format
- Adjusted CMakeLists.txt where needed
- Added description to the guides

## Type of Change

Please select (at least one):
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation / examples / tutorials / demos
- [ ] Supporting functionality change (fix or feature in documentation generation, helper scripts, ...)
- [ ] Refactoring / internal change
- [ ] Other (please describe):

## Testing

Checklist for testing:
- [x] Tests added or updated if/as needed
- [ ] Repository test runner executed: `scripts/run_tests.sh`

Optionally, add a brief description.

## Documentation, Examples, Tutorials, Demos

Checklist for documentation:
- [x] User-facing documentation updated if/as needed (including API docs)
- [x] Examples / tutorials / demos updated or added (if relevant)
- [ ] Limitations and constraints documented (if relevant)
- [ ] Performance documented (if relevant)
- [x] Documentation building successful & checks outlined in the [Documentation Checks](/NVIDIA/ACCV-Lab/blob/main/docs/guides/CONTRIBUTION_GUIDE.md#documentation-checks) section of the [Contribution Guide](/NVIDIA/ACCV-Lab/blob/main/docs/guides/CONTRIBUTION_GUIDE.md) are performed

Optionally, add a brief description.

## Code Quality

Checklist for dependencies:
  - [ ] Dependencies updated in the relevant `pyproject.toml` if/as needed
  - [x] Code formatted according to the [Code Formatting Guide](/NVIDIA/ACCV-Lab/blob/main/docs/guides/FORMATTING_GUIDE.md)

Optionally, add a brief description.

## Related Issues / Context

If applicable, link related issues, discussions etc.

---

## DCO / Sign-Off

Please refer to the section on [Signing Your Work & Developer Certificate of Origin (DCO)](/NVIDIA/ACCV-Lab/blob/main/docs/guides/CONTRIBUTION_GUIDE.md#signing-your-work--developer-certificate-of-origin-dco)
in the Contribution Guide before submitting your contribution.

## References

For additional details, please refer to the [Contribution Guide](/NVIDIA/ACCV-Lab/blob/main/docs/guides/CONTRIBUTION_GUIDE.md).
The following guides are available (referenced in the Contribution Guide for further details):
- [`docs/guides/CONTRIBUTION_GUIDE.md`](/NVIDIA/ACCV-Lab/blob/main/docs/guides/CONTRIBUTION_GUIDE.md)
- [`docs/guides/DEVELOPMENT_GUIDE.md`](/NVIDIA/ACCV-Lab/blob/main/docs/guides/DEVELOPMENT_GUIDE.md)
- [`docs/guides/DOCUMENTATION_SETUP_GUIDE.md`](/NVIDIA/ACCV-Lab/blob/main/docs/guides/DOCUMENTATION_SETUP_GUIDE.md)
- [`docs/guides/FORMATTING_GUIDE.md`](/NVIDIA/ACCV-Lab/blob/main/docs/guides/FORMATTING_GUIDE.md)

Please also refer to the [summary checklist in the Contribution Guide](/NVIDIA/ACCV-Lab/blob/main/docs/guides/CONTRIBUTION_GUIDE.md#summary-checklist),
which is a guideline for what to consider when submitting your contribution and covers the same topics as the checklists above.
