### PR TITLE
Fix NVDEC display frame cleanup on exceptions

### DIFF
--- a/packages/on_demand_video_decoder/ext_impl/src/VideoCodecSDKUtils/helper_classes/NvCodec/NvDecoder/NvDecoder.cpp
+++ b/packages/on_demand_video_decoder/ext_impl/src/VideoCodecSDKUtils/helper_classes/NvCodec/NvDecoder/NvDecoder.cpp
@@ -18,6 +18,7 @@
 #include <algorithm>
 #include <chrono>
 #include <cmath>
+#include <utility>
 
 #include "../../../Interface/nvcuvid.h"
 #include "NvDecoder/NvDecoder.h"
@@ -46,6 +47,33 @@ simplelogger::Logger *logger = simplelogger::LoggerFactory::CreateConsoleLogger(
         }                                                                                                                        \
     }                                                                                                                            \
     while (0)
+
+namespace {
+
+template <typename Cleanup>
+class ScopeExit {
+public:
+    explicit ScopeExit(Cleanup cleanup) : cleanup_(std::move(cleanup)) {}
+    ScopeExit(const ScopeExit&) = delete;
+    ScopeExit& operator=(const ScopeExit&) = delete;
+
+    ~ScopeExit() noexcept {
+        if (active_) {
+            cleanup_();
+        }
+    }
+
+    void Dismiss() noexcept { active_ = false; }
+
+private:
+    Cleanup cleanup_;
+    bool active_ = true;
+};
+
+template <typename Cleanup>
+ScopeExit(Cleanup) -> ScopeExit<Cleanup>;
+
+}  // namespace
 
 static const char * GetVideoCodecString(cudaVideoCodec eCodec) {
     static struct {
@@ -693,9 +721,12 @@ int NvDecoder::HandlePictureDisplay(CUVIDPARSERDISPINFO *pDispInfo) {
     CUdeviceptr dpSrcFrame = 0;
     unsigned int nSrcPitch = 0;
     CUDA_DRVAPI_CALL(cuCtxPushCurrent(m_cuContext));
+    auto contextCleanup = ScopeExit([]() noexcept { cuCtxPopCurrent(NULL); });
     NVTX_SCOPED_RANGE("display")
     NVDEC_API_CALL(m_api.cuvidMapVideoFrame(m_hDecoder, pDispInfo->picture_index, &dpSrcFrame,
         &nSrcPitch, &videoProcessingParameters));
+    auto frameCleanup = ScopeExit(
+        [&]() noexcept { m_api.cuvidUnmapVideoFrame(m_hDecoder, dpSrcFrame); });
 
     CUVIDGETDECODESTATUS DecodeStatus;
     memset(&DecodeStatus, 0, sizeof(DecodeStatus));
@@ -776,14 +807,15 @@ int NvDecoder::HandlePictureDisplay(CUVIDPARSERDISPINFO *pDispInfo) {
         }
     }
     
-    CUDA_DRVAPI_CALL(cuCtxPopCurrent(NULL));
-
     if ((int)m_vTimestamp.size() < m_nDecodedFrame) {
         m_vTimestamp.resize(m_vpFrame.size());
     }
     m_vTimestamp[m_nDecodedFrame - 1] = pDispInfo->timestamp;
 
     NVDEC_API_CALL(m_api.cuvidUnmapVideoFrame(m_hDecoder, dpSrcFrame));
+    frameCleanup.Dismiss();
+    CUDA_DRVAPI_CALL(cuCtxPopCurrent(NULL));
+    contextCleanup.Dismiss();
     return 1;
 }
 


### PR DESCRIPTION
## Description

`NvDecoder::HandlePictureDisplay` pushes a CUDA context and maps an NVDEC
display surface before allocating/copying the output frame. Several operations
between `cuvidMapVideoFrame` and the final cleanup can throw.

Previously, such an exception skipped both `cuvidUnmapVideoFrame` and
`cuCtxPopCurrent`. The leaked display mapping could then make a later
`cuvidMapVideoFrame` fail with `CUDA_ERROR_ALREADY_MAPPED`, obscuring the
original allocation, copy, or synchronization failure.

This change adds small scope-exit guards for the current CUDA context and mapped
display surface. During stack unwinding they perform best-effort cleanup without
replacing the original exception. The normal path still uses the checked CUDA
and NVDEC calls, then dismisses the guards.

This does not attempt to fix the first CUDA error; it prevents that error from
leaking decoder resources and causing a misleading secondary failure.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation / examples / tutorials / demos
- [ ] Supporting functionality change (fix or feature in documentation generation, helper scripts, ...)
- [ ] Refactoring / internal change
- [ ] Other (please describe):

## Testing

- [ ] Tests added or updated if/as needed
- [ ] Repository test runner executed: `scripts/run_tests.sh`

Validation performed:

- Compiled `NvDecoder.cpp` directly with the repository's C++17 compile flags.
- Configured and built the complete `_PyNvOnDemandDecoder` extension with CUDA
  12.8.
- Used the newly built extension on an NVIDIA GPU for 20 repeated H.264 NVDEC
  RGB decodes; every output was non-empty with shape `(256, 256, 3)`.
- `git clang-format --diff origin/main` reports no formatting changes.
- `git diff --check` passes.

A deterministic test for the cleanup branch would require injecting a CUDA or
NVDEC failure after a successful `cuvidMapVideoFrame`. No production fault hook
was added solely for that purpose.

## Documentation, Examples, Tutorials, Demos

- [ ] User-facing documentation updated if/as needed (including API docs)
- [ ] Examples / tutorials / demos updated or added (if relevant)
- [ ] Limitations and constraints documented (if relevant)
- [ ] Performance documented (if relevant)
- [ ] Documentation building successful & checks outlined in the [Documentation Checks](/NVIDIA/ACCV-Lab/blob/main/docs/guides/CONTRIBUTION_GUIDE.md#documentation-checks) section of the [Contribution Guide](/NVIDIA/ACCV-Lab/blob/main/docs/guides/CONTRIBUTION_GUIDE.md) are performed

No user-facing API or behavior is changed.

## Code Quality

- [ ] Dependencies updated in the relevant `pyproject.toml` if/as needed
- [x] Code formatted according to the [Code Formatting Guide](/NVIDIA/ACCV-Lab/blob/main/docs/guides/FORMATTING_GUIDE.md)

No dependencies are added.

## Related Issues / Context

The affected map/unmap sequence has been present since the initial ACCV-Lab
import of the Video Codec SDK helper. No existing ACCV-Lab issue or pull request
covering this exception-safety gap was found.

---

## DCO / Sign-Off

The commit includes a `Signed-off-by` line.
