### PR TITLE
sweep: bugfix in packages/draw_heatmap/accvlab/draw_heatmap/__init__.py

### DIFF
--- a/packages/draw_heatmap/accvlab/draw_heatmap/__init__.py
+++ b/packages/draw_heatmap/accvlab/draw_heatmap/__init__.py
@@ -19,6 +19,6 @@ try:
 except PackageNotFoundError:
     __version__ = "0.0.0"
 
-from .funtions import draw_heatmap, draw_heatmap_batched
+from .functions import draw_heatmap, draw_heatmap_batched
 
 __all__ = ["__version__", "draw_heatmap", "draw_heatmap_batched"]


### PR DESCRIPTION
## Bugfix sweep for `packages/draw_heatmap/accvlab/draw_heatmap/__init__.py`

### Problem
typo funtions

### Fix
--- a/packages/draw_heatmap/accvlab/draw_heatmap/__init__.py
+++ b/packages/draw_heatmap/accvlab/draw_heatmap/__init__.py
@@ -19,7 +19,7 @@
 try:
     __version__ = version('accvlab.draw_heatmap')
 except PackageNotFoundError:
     __version__ = '0.0.0'
 
-from .funtions import draw_heatmap, draw_heatmap_batched
+from .functions import draw_heatmap, draw_heatmap_batched
 
 __all__ = ['__version__', 'draw_heatmap', 'draw_heatmap_batched']


### Reasoning
Fix typo in import path.

### Test
Framework: `pytest`
