### PR TITLE
fix get gop stride bug, when numpy>2.0

### DIFF
--- a/packages/on_demand_video_decoder/ext_impl/src/PyNvOnDemandDecoder/src/PyNvGopDecoder_constructors.cpp
+++ b/packages/on_demand_video_decoder/ext_impl/src/PyNvOnDemandDecoder/src/PyNvGopDecoder_constructors.cpp
@@ -541,8 +541,10 @@ void Init_PyNvGopDecoder(py::module& m) {
                         // Create numpy array from serialized data for this video
                         auto capsule = py::capsule(bundle.data.release(),
                                                    [](void* ptr) { delete[] static_cast<uint8_t*>(ptr); });
-                        py::array_t<uint8_t> numpy_data(
-                            bundle.size, static_cast<uint8_t*>(capsule.get_pointer()), capsule);
+                        py::array_t<uint8_t> numpy_data({static_cast<py::ssize_t>(bundle.size)},
+                                                        {static_cast<py::ssize_t>(sizeof(uint8_t))},
+                                                        static_cast<uint8_t*>(capsule.get_pointer()),
+                                                        capsule);
 
                         // Create tuple (numpy_data, first_frame_ids, gop_lens) for this video
                         py::tuple video_tuple =
@@ -1218,7 +1220,9 @@ void Init_PyNvGopDecoder(py::module& m) {
                             py::capsule(raw_ptr, [](void* ptr) { delete[] static_cast<uint8_t*>(ptr); });
 
                         // Create numpy array
-                        py::array_t<uint8_t> numpy_data(size, raw_ptr, capsule);
+                        py::array_t<uint8_t> numpy_data({static_cast<py::ssize_t>(size)},
+                                                        {static_cast<py::ssize_t>(sizeof(uint8_t))}, raw_ptr,
+                                                        capsule);
 
                         result_list.append(std::move(numpy_data));
                     }

--- a/packages/on_demand_video_decoder/tests/test_gop_cache.py
+++ b/packages/on_demand_video_decoder/tests/test_gop_cache.py
@@ -19,6 +19,9 @@ This module tests the useGOPCache parameter for the GetGOPList method,
 including cache hit/miss scenarios, cache management, and data correctness.
 """
 
+from pathlib import Path
+
+import numpy as np
 import pytest
 import sys
 import torch
@@ -45,6 +48,17 @@ def _gop_ranges(gop_list):
     first_ids = [bundle[1][0] for bundle in gop_list]
     gop_lens = [bundle[2][0] for bundle in gop_list]
     return first_ids, gop_lens
+
+
+def _assert_contiguous_byte_bundle(bundle: np.ndarray, expected: bytes) -> None:
+    assert isinstance(bundle, np.ndarray)
+    assert bundle.dtype == np.dtype(np.uint8)
+    assert bundle.ndim == 1
+    assert bundle.itemsize == 1
+    assert bundle.strides == (1,)
+    assert bundle.flags.c_contiguous
+    assert bundle.nbytes == len(expected)
+    assert bundle.tobytes() == expected
 
 
 class TestGetGOPListCache:
@@ -94,6 +108,19 @@ class TestGetGOPListCache:
             assert all(not hit for hit in cache_hits), "First call should be all cache misses"
 
         print(f"✓ Test passed: Got {len(gop_list)} GOP bundles")
+
+    def test_gop_bundle_numpy_layout(self, decoder, tmp_path):
+        """Serialized GOP bundles stay contiguous on NumPy 1.x and 2.x."""
+        sample_video = Path(utils.get_data_dir()) / "sample_clip" / "moving_shape_circle_h265.mp4"
+        bundle = decoder.GetGOPList([str(sample_video)], [10], useGOPCache=False)[0][0]
+
+        gop_path = tmp_path / "serialized.gop"
+        nvc.SaveGopToFile(bundle, str(gop_path))
+        expected = gop_path.read_bytes()
+        _assert_contiguous_byte_bundle(bundle, expected)
+
+        loaded = decoder.LoadGopsToList([str(gop_path)])[0]
+        _assert_contiguous_byte_bundle(loaded, expected)
 
     def test_getgoplist_cache_hit(self, decoder, test_files_and_frames):
         """


### PR DESCRIPTION
## Description

Fix get gop stride bug, when numpy>2.0.
Update pybind11 from v2.10.0 to v2.12.1.

## Type of Change

Please select (at least one):
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation / examples / tutorials / demos
- [ ] Supporting functionality change (fix or feature in documentation generation, helper scripts, ...)
- [ ] Refactoring / internal change
- [ ] Other (please describe):

## Testing

Checklist for testing:
- [x] Tests added or updated if/as needed
- [ ] Repository test runner executed: `scripts/run_tests.sh`

Optionally, add a brief description.

## Documentation, Examples, Tutorials, Demos

Checklist for documentation:
- [ ] User-facing documentation updated if/as needed (including API docs)
- [ ] Examples / tutorials / demos updated or added (if relevant)
- [ ] Limitations and constraints documented (if relevant)
- [ ] Performance documented (if relevant)
- [ ] Documentation building successful & checks outlined in the [Documentation Checks](/NVIDIA/ACCV-Lab/blob/main/docs/guides/CONTRIBUTION_GUIDE.md#documentation-checks) section of the [Contribution Guide](/NVIDIA/ACCV-Lab/blob/main/docs/guides/CONTRIBUTION_GUIDE.md) are performed

Optionally, add a brief description.

## Code Quality

Checklist for dependencies:
  - [ ] Dependencies updated in the relevant `pyproject.toml` if/as needed
  - [x] Code formatted according to the [Code Formatting Guide](/NVIDIA/ACCV-Lab/blob/main/docs/guides/FORMATTING_GUIDE.md)

Optionally, add a brief description.

## Related Issues / Context

If applicable, link related issues, discussions etc.

---

## DCO / Sign-Off

Please refer to the section on [Signing Your Work & Developer Certificate of Origin (DCO)](/NVIDIA/ACCV-Lab/blob/main/docs/guides/CONTRIBUTION_GUIDE.md#signing-your-work--developer-certificate-of-origin-dco)
in the Contribution Guide before submitting your contribution.

## References

For additional details, please refer to the [Contribution Guide](/NVIDIA/ACCV-Lab/blob/main/docs/guides/CONTRIBUTION_GUIDE.md).
The following guides are available (referenced in the Contribution Guide for further details):
- [`docs/guides/CONTRIBUTION_GUIDE.md`](/NVIDIA/ACCV-Lab/blob/main/docs/guides/CONTRIBUTION_GUIDE.md)
- [`docs/guides/DEVELOPMENT_GUIDE.md`](/NVIDIA/ACCV-Lab/blob/main/docs/guides/DEVELOPMENT_GUIDE.md)
- [`docs/guides/DOCUMENTATION_SETUP_GUIDE.md`](/NVIDIA/ACCV-Lab/blob/main/docs/guides/DOCUMENTATION_SETUP_GUIDE.md)
- [`docs/guides/FORMATTING_GUIDE.md`](/NVIDIA/ACCV-Lab/blob/main/docs/guides/FORMATTING_GUIDE.md)

Please also refer to the [summary checklist in the Contribution Guide](/NVIDIA/ACCV-Lab/blob/main/docs/guides/CONTRIBUTION_GUIDE.md#summary-checklist),
which is a guideline for what to consider when submitting your contribution and covers the same topics as the checklists above.
